### PR TITLE
ROX-31485: Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Git and jj files
+.git/
+.jj/
+.gitignore
+.gitattributes
+
+# CI/CD
+.github/
+
+# IDE and editor files
+.vscode/
+.idea/
+.DS_Store
+
+# Test coverage output
+/*.out
+
+# Build output
+/stackrox-mcp
+
+# Lint output
+/report.xml
+
+# Documentation
+*.md
+docs/
+LICENSE

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
 
       - name: Check code formatting
         run: make fmt-check
@@ -33,3 +31,8 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.6
+
+      - name: Run hadolint
+        uses: hadolint/hadolint-action@v3.3.0
+        with:
+          dockerfile: Dockerfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
 
       - name: Download dependencies
         run: go mod download

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 version: "2"
 run:
   timeout: 240m
-  go: "1.24"
   modules-download-mode: readonly
   allow-parallel-runners: true
 output:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# Multi-stage Dockerfile for StackRox MCP Server
+
+# Used images
+ARG GOLANG_BUILDER=registry.access.redhat.com/ubi10/go-toolset:1.25
+ARG MCP_SERVER_BASE_IMAGE=registry.access.redhat.com/ubi10/ubi-micro:10.1
+
+# Stage 1: Builder - Build the Go binary
+FROM $GOLANG_BUILDER AS builder
+
+# Build arguments for multi-arch support
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+ARG VERSION=dev
+
+# Set working directory
+WORKDIR /workspace
+
+# Copy go module files first for better layer caching
+COPY go.mod go.sum ./
+
+# Download dependencies (cached layer)
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the binary with optimizations
+# Output to "/tmp" directory, because user can not copy built binary to "/workspace"
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build \
+    -ldflags="-w -s" \
+    -trimpath \
+    -o /tmp/stackrox-mcp \
+    ./cmd/stackrox-mcp
+
+# Stage 2: Runtime - Minimal runtime image
+FROM $MCP_SERVER_BASE_IMAGE
+
+# Set default environment variables
+ENV LOG_LEVEL=INFO
+
+# Set working directory
+WORKDIR /app
+
+# Copy binary from builder
+COPY --from=builder /tmp/stackrox-mcp /app/stackrox-mcp
+
+# Set ownership to non-root user
+RUN chown -R 4000:4000 /app
+
+# Switch to non-root user
+USER 4000
+
+# Expose port for MCP server
+EXPOSE 8080
+
+# Run the application
+ENTRYPOINT ["/app/stackrox-mcp"]

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ GOTEST=$(GOCMD) test
 GOFMT=$(GOCMD) fmt
 GOCLEAN=$(GOCMD) clean
 
+# Set the container runtime command - prefer podman, fallback to docker
+DOCKER_CMD = $(shell command -v podman >/dev/null 2>&1 && echo podman || echo docker)
+
 # Build flags
 LDFLAGS=-ldflags "-X github.com/stackrox/stackrox-mcp/internal/server.version=$(VERSION)"
 
@@ -34,6 +37,14 @@ help: ## Display this help message
 .PHONY: build
 build: ## Build the binary
 	$(GOBUILD) $(LDFLAGS) -o $(BINARY_NAME) ./cmd/stackrox-mcp
+
+.PHONY: image
+image: ## Build the docker image
+	$(DOCKER_CMD) build -t quay.io/stackrox-io/stackrox-mcp:$(VERSION) .
+
+.PHONY: dockerfile-lint
+dockerfile-lint: ## Run hadolint for Dockerfile
+	$(DOCKER_CMD) run --rm -i --env HADOLINT_FAILURE_THRESHOLD=info ghcr.io/hadolint/hadolint < Dockerfile
 
 .PHONY: test
 test: ## Run unit tests

--- a/README.md
+++ b/README.md
@@ -173,6 +173,34 @@ You: "Can you list all the clusters from StackRox?"
 Claude: [Uses list_clusters tool to retrieve cluster information]
 ```
 
+## Docker
+
+### Building the Docker Image
+
+Build the image locally:
+```bash
+VERSION=dev make image
+```
+
+### Running the Container
+
+Run with default settings:
+```bash
+docker run --publish 8080:8080  --env STACKROX_MCP__TOOLS__CONFIG_MANAGER__ENABLED=true --env STACKROX_MCP__CENTRAL__URL=<central host:port> quay.io/stackrox-io/stackrox-mcp:dev
+```
+
+### Build Arguments
+
+- `TARGETOS` - Target operating system (default: `linux`)
+- `TARGETARCH` - Target architecture (default: `amd64`)
+- `VERSION` - Application version (default: `dev`)
+
+### Image Details
+
+- **Base Image**: Red Hat UBI10-micro (minimal, secure)
+- **User**: Non-root user `mcp` (UID/GID 4000)
+- **Port**: 8080
+
 ## Development
 
 For detailed development guidelines, testing standards, and contribution workflows, see [CONTRIBUTING.md](.github/CONTRIBUTING.md).

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/stackrox/stackrox-mcp
 
-go 1.24.0
-
-toolchain go1.24.7
+go 1.25
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.1.0


### PR DESCRIPTION
### Description

This PR is adding the following changes:
- Dockerfile to build MCP server image
- `/health` endpoint to support K8s deployment readiness
- new target in Makefile
- documentation update in README
- bump go version to `1.25`
- add dockerfile linter

### Validation

- [x] build image locally
- [x] run docker container and test with MCP inspector
- [x] validate that `/health` endpoint works

*Info about layer caching*
```
[1/2] STEP 1/10: FROM registry.access.redhat.com/ubi10/ubi:latest AS builder
[1/2] STEP 2/10: ARG TARGETOS=linux
--> Using cache 9bd8d6b87dc7fe94cf6e9a71a1c5404ab3985d6a4bd3e1920e646d69b9b9daf5
--> 9bd8d6b87dc7
[1/2] STEP 3/10: ARG TARGETARCH=amd64
--> Using cache 08722e7b3772a42b01126f9db37606cb52716dd6efebbed841d804f6cdb1126d
--> 08722e7b3772
[1/2] STEP 4/10: ARG VERSION=dev
--> Using cache 7fd092f50e973c653046241b78d6afcecdac5093a747a7c4ce24f5e509a6ce37
--> 7fd092f50e97
[1/2] STEP 5/10: RUN dnf install -y golang && dnf clean all
--> Using cache 44ca1995aab21363aa88b96ac6e4924ae48126d2bbcc72818520926b8a0b2433
--> 44ca1995aab2
[1/2] STEP 6/10: WORKDIR /workspace
--> Using cache 5b91f34d8e6ce6f53babce4f40afdf19546180bb9cc1b82a2d9f55d6908a786e
--> 5b91f34d8e6c
[1/2] STEP 7/10: COPY go.mod go.sum ./
--> Using cache 6ab9bc41fe53041c20bf836a7adf851b8415614afe28d58c72f397c628680597
--> 6ab9bc41fe53
[1/2] STEP 8/10: RUN go mod download
--> Using cache b2c875fa3b3bf75749bfc4ccb3091dd6784f1700872cfa3d422b5bbfc0d38c54
--> b2c875fa3b3b
[1/2] STEP 9/10: COPY . .
--> 1d085c167014
```