### PR TITLE
ROX-31485: Add build and push image to repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,79 @@
+name: Build and Push Container Images
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: stackrox-io/mcp
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=sha,prefix=,format=short
+          labels: |
+            summary=StackRox MCP Server
+            description=Model Context Protocol server for StackRox
+            maintainer=https://stackrox.io/
+            vendor=StackRox
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+
+      - name: Generate build summary
+        run: |
+          echo "## Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Registry**: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Tags**:" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Platforms**: linux/amd64, linux/arm64, linux/ppc64le, linux/s390x" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,17 @@
 ARG GOLANG_BUILDER=registry.access.redhat.com/ubi10/go-toolset:1.25
 ARG MCP_SERVER_BASE_IMAGE=registry.access.redhat.com/ubi10/ubi-micro:10.1
 
-# Stage 1: Builder - Build the Go binary
-FROM $GOLANG_BUILDER AS builder
+# Build arguments for multi-arch build support
+ARG BUILDPLATFORM
 
-# Build arguments for multi-arch support
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+# Stage 1: Builder - Build the Go binary
+FROM --platform=$BUILDPLATFORM $GOLANG_BUILDER AS builder
+
+# Build arguments for multi-arch target
+ARG TARGETOS
+ARG TARGETARCH
+
+# Build arguments for application version
 ARG VERSION=dev
 
 # Set working directory

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 # Binary name
 BINARY_NAME=stackrox-mcp
 
-# Version (can be overridden with VERSION=x.y.z make build)
-VERSION?=0.1.0
+# Version can be overridden with VERSION=x.y.z make build (default: extracted from git tags or use dev)
+VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 
 # Go parameters
 GOCMD=go
@@ -40,7 +40,10 @@ build: ## Build the binary
 
 .PHONY: image
 image: ## Build the docker image
-	$(DOCKER_CMD) build -t quay.io/stackrox-io/stackrox-mcp:$(VERSION) .
+	$(DOCKER_CMD) build \
+		--build-arg VERSION=$(VERSION) \
+		-t quay.io/stackrox-io/mcp:$(VERSION) \
+		.
 
 .PHONY: dockerfile-lint
 dockerfile-lint: ## Run hadolint for Dockerfile

--- a/README.md
+++ b/README.md
@@ -173,33 +173,82 @@ You: "Can you list all the clusters from StackRox?"
 Claude: [Uses list_clusters tool to retrieve cluster information]
 ```
 
-## Docker
+## Container Images
 
-### Building the Docker Image
+### Registry
 
-Build the image locally:
-```bash
-VERSION=dev make image
+Official images are published to Quay.io:
+
+```
+quay.io/stackrox-io/mcp
 ```
 
-### Running the Container
+### Supported Architectures
 
-Run with default settings:
+Multi-architecture images support the following platforms:
+
+- `linux/amd64` - Standard x86_64 architecture
+- `linux/arm64` - ARM 64-bit (Apple Silicon, AWS Graviton, etc.)
+- `linux/ppc64le` - IBM POWER architecture
+- `linux/s390x` - IBM Z mainframe architecture
+
+Docker/Podman will automatically pull the correct image for your platform.
+
+### Available Tags
+
+| Tag Pattern | Description | Example |
+|-------------|-------------|---------|
+| `latest` | Latest release version | `quay.io/stackrox-io/mcp:latest` |
+| `v{version}` | Specific release version | `quay.io/stackrox-io/mcp:v1.0.0` |
+| `{commit-sha}` | Specific commit from main branch | `quay.io/stackrox-io/mcp:a1b2c3d` |
+
+### Usage
+
+#### Pull Image
+
 ```bash
-docker run --publish 8080:8080  --env STACKROX_MCP__TOOLS__CONFIG_MANAGER__ENABLED=true --env STACKROX_MCP__CENTRAL__URL=<central host:port> quay.io/stackrox-io/stackrox-mcp:dev
+docker pull quay.io/stackrox-io/mcp:latest
+# or
+podman pull quay.io/stackrox-io/mcp:latest
+```
+
+#### Run Container
+
+```bash
+docker run -p 8080:8080 \
+  --env STACKROX_MCP__CENTRAL__URL=central.stackrox:443 \
+  --env STACKROX_MCP__TOOLS__CONFIG_MANAGER__ENABLED=true \
+  quay.io/stackrox-io/mcp:latest
+```
+
+### Building Images Locally
+
+Build a single-platform image:
+```bash
+VERSION=dev make image
 ```
 
 ### Build Arguments
 
 - `TARGETOS` - Target operating system (default: `linux`)
 - `TARGETARCH` - Target architecture (default: `amd64`)
-- `VERSION` - Application version (default: `dev`)
+- `VERSION` - Application version (default: auto-detected from git)
 
 ### Image Details
 
 - **Base Image**: Red Hat UBI10-micro (minimal, secure)
-- **User**: Non-root user `mcp` (UID/GID 4000)
+- **User**: Non-root user (UID/GID 4000)
 - **Port**: 8080
+- **Health Check**: Built-in health endpoint at `/health`
+
+### Automated Builds
+
+Images are automatically built and pushed on:
+
+- **Main branch commits**: Tagged with commit SHA
+- **Version tags**: Tagged with version number and `latest`
+
+See [.github/workflows/build.yml](.github/workflows/build.yml) for build pipeline details.
 
 ## Development
 


### PR DESCRIPTION
### Description

This PR adds build and push image to `quay.io`.

- we build and push images for for architectures (`amd64`, `arm64`, `ppc64le`, and `s390x`)
- README is updated to reflect changes
- Dockerfile is adjusted to support cross-platform compiling
- Makefile `VERSION` is changed to take git commit

### Validation

- [x] checked pushed image: https://quay.io/repository/stackrox-io/mcp?tab=tags
- [x] pull and run image locally

