### PR TITLE
ROX-31478: Implement list clusters tool

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/pkg/errors"
@@ -141,6 +142,18 @@ func (c *Client) ReadyConn(ctx context.Context) (*grpc.ClientConn, error) {
 	}
 
 	return c.conn, nil
+}
+
+// SetConnForTesting sets a gRPC connection for testing purposes.
+// This should only be used in tests.
+func (c *Client) SetConnForTesting(t *testing.T, conn *grpc.ClientConn) {
+	t.Helper()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.conn = conn
+	c.connected = true
 }
 
 func (c *Client) shouldRedialNoLock() bool {

--- a/internal/toolsets/config/tools_test.go
+++ b/internal/toolsets/config/tools_test.go
@@ -1,12 +1,23 @@
 package config
 
 import (
+	"context"
+	"fmt"
+	"net"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/stackrox-mcp/internal/client"
+	"github.com/stackrox/stackrox-mcp/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 func TestNewListClustersTool(t *testing.T) {
@@ -30,6 +41,7 @@ func TestListClustersTool_GetTool(t *testing.T) {
 	require.NotNil(t, mcpTool)
 	assert.Equal(t, "list_clusters", mcpTool.Name)
 	assert.NotEmpty(t, mcpTool.Description)
+	require.NotNil(t, mcpTool.InputSchema, "InputSchema should be defined")
 }
 
 func TestListClustersTool_RegisterWith(t *testing.T) {
@@ -46,4 +58,225 @@ func TestListClustersTool_RegisterWith(t *testing.T) {
 	assert.NotPanics(t, func() {
 		tool.RegisterWith(server)
 	})
+}
+
+// Mock infrastructure for gRPC testing.
+
+// mockClustersService implements v1.ClustersServiceServer for testing.
+type mockClustersService struct {
+	v1.UnimplementedClustersServiceServer
+
+	clusters []*storage.Cluster
+	err      error
+}
+
+func (m *mockClustersService) GetClusters(
+	_ context.Context,
+	_ *v1.GetClustersRequest,
+) (*v1.ClustersList, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return &v1.ClustersList{
+		Clusters: m.clusters,
+	}, nil
+}
+
+// setupMockServer creates an in-memory gRPC server using bufconn.
+func setupMockServer(mockService *mockClustersService) (*grpc.Server, *bufconn.Listener) {
+	buffer := 1024 * 1024
+	listener := bufconn.Listen(buffer)
+
+	grpcServer := grpc.NewServer()
+	v1.RegisterClustersServiceServer(grpcServer, mockService)
+
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+
+	return grpcServer, listener
+}
+
+// bufDialer creates a dialer function for bufconn.
+func bufDialer(listener *bufconn.Listener) func(context.Context, string) (net.Conn, error) {
+	return func(_ context.Context, _ string) (net.Conn, error) {
+		return listener.Dial()
+	}
+}
+
+// createTestClient creates a client connected to the mock server.
+func createTestClient(t *testing.T, listener *bufconn.Listener) *client.Client {
+	t.Helper()
+
+	conn, err := grpc.NewClient(
+		"passthrough://buffer",
+		grpc.WithLocalDNSResolution(),
+		grpc.WithContextDialer(bufDialer(listener)),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	stackroxClient, err := client.NewClient(&config.CentralConfig{
+		URL: "buffer",
+	})
+	require.NoError(t, err)
+
+	// Inject mock connection for testing.
+	stackroxClient.SetConnForTesting(t, conn)
+
+	return stackroxClient
+}
+
+func TestHandle_DefaultLimit(t *testing.T) {
+	mockService := &mockClustersService{
+		clusters: []*storage.Cluster{
+			{Id: "c1", Name: "Cluster 1", Type: storage.ClusterType_KUBERNETES_CLUSTER},
+			{Id: "c2", Name: "Cluster 2", Type: storage.ClusterType_KUBERNETES_CLUSTER},
+			{Id: "c3", Name: "Cluster 3", Type: storage.ClusterType_KUBERNETES_CLUSTER},
+			{Id: "c4", Name: "Cluster 4", Type: storage.ClusterType_KUBERNETES_CLUSTER},
+			{Id: "c5", Name: "Cluster 5", Type: storage.ClusterType_KUBERNETES_CLUSTER},
+		},
+	}
+
+	grpcServer, listener := setupMockServer(mockService)
+	defer grpcServer.Stop()
+
+	testClient := createTestClient(t, listener)
+	tool, ok := NewListClustersTool(testClient).(*listClustersTool)
+	require.True(t, ok)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+	input := listClustersInput{
+		Offset: defaultOffset,
+		Limit:  defaultOffset,
+	}
+
+	result, output, err := tool.handle(ctx, req, input)
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Nil(t, result) // MCP SDK handles result creation
+
+	require.Len(t, output.Clusters, 5)
+	assert.Equal(t, 5, output.TotalCount)
+	assert.Equal(t, 0, output.Offset)
+	assert.Equal(t, 0, output.Limit)
+	assert.Equal(t, "Cluster 1", output.Clusters[0].Name)
+	assert.Equal(t, "Cluster 5", output.Clusters[4].Name)
+}
+
+//nolint:funlen
+func TestHandle_WithPagination(t *testing.T) {
+	totalClusters := 10
+
+	clusters := make([]*storage.Cluster, totalClusters)
+	for i := range totalClusters {
+		clusters[i] = &storage.Cluster{
+			Id:   fmt.Sprintf("cluster-%d", i),
+			Name: fmt.Sprintf("Cluster %d", i),
+			Type: storage.ClusterType_KUBERNETES_CLUSTER,
+		}
+	}
+
+	mockService := &mockClustersService{
+		clusters: clusters,
+	}
+
+	grpcServer, listener := setupMockServer(mockService)
+	defer grpcServer.Stop()
+
+	testClient := createTestClient(t, listener)
+	tool, ok := NewListClustersTool(testClient).(*listClustersTool)
+	require.True(t, ok)
+
+	tests := map[string]struct {
+		offset        int
+		limit         int
+		expectedCount int
+		expectedFirst string
+		expectedLast  string
+	}{
+		"first page": {
+			offset:        0,
+			limit:         3,
+			expectedCount: 3,
+			expectedFirst: "cluster-0",
+			expectedLast:  "cluster-2",
+		},
+		"middle page": {
+			offset:        2,
+			limit:         3,
+			expectedCount: 3,
+			expectedFirst: "cluster-2",
+			expectedLast:  "cluster-4",
+		},
+		"partial page": {
+			offset:        8,
+			limit:         10,
+			expectedCount: 2,
+			expectedFirst: "cluster-8",
+			expectedLast:  "cluster-9",
+		},
+		"offset beyond total": {
+			offset:        100,
+			limit:         10,
+			expectedCount: 0,
+		},
+	}
+
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			ctx := context.Background()
+			req := &mcp.CallToolRequest{}
+			input := listClustersInput{
+				Offset: testCase.offset,
+				Limit:  testCase.limit,
+			}
+
+			result, output, err := tool.handle(ctx, req, input)
+
+			require.NoError(t, err)
+			require.NotNil(t, output)
+			assert.Nil(t, result) // MCP SDK handles result creation.
+
+			assert.Len(t, output.Clusters, testCase.expectedCount)
+			assert.Equal(t, totalClusters, output.TotalCount)
+			assert.Equal(t, testCase.offset, output.Offset)
+			assert.Equal(t, testCase.limit, output.Limit)
+
+			if testCase.expectedCount > 0 {
+				assert.Equal(t, testCase.expectedFirst, output.Clusters[0].ID)
+				assert.Equal(t, testCase.expectedLast, output.Clusters[testCase.expectedCount-1].ID)
+			}
+		})
+	}
+}
+
+func TestHandle_GetClustersError(t *testing.T) {
+	mockService := &mockClustersService{
+		err: status.Error(codes.Internal, "test"),
+	}
+
+	grpcServer, listener := setupMockServer(mockService)
+	defer grpcServer.Stop()
+
+	testClient := createTestClient(t, listener)
+	tool, ok := NewListClustersTool(testClient).(*listClustersTool)
+	require.True(t, ok)
+
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+	input := listClustersInput{
+		Offset: 0,
+		Limit:  10,
+	}
+
+	result, output, err := tool.handle(ctx, req, input)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Nil(t, output)
+	assert.Contains(t, err.Error(), "Internal server error")
 }

--- a/internal/toolsets/utils.go
+++ b/internal/toolsets/utils.go
@@ -1,0 +1,18 @@
+package toolsets
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/stackrox/stackrox-mcp/internal/logging"
+)
+
+// MustJSONMarshal marshals value into a raw encoded JSON value or crashes.
+func MustJSONMarshal(value any) json.RawMessage {
+	marshaledValue, err := json.Marshal(value)
+	if err != nil {
+		logging.Fatal(fmt.Sprintf("marshaling failed for value: %v", value), err)
+	}
+
+	return marshaledValue
+}

--- a/internal/toolsets/utils_test.go
+++ b/internal/toolsets/utils_test.go
@@ -1,0 +1,182 @@
+package toolsets
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMustMarshal_SimpleTypes tests marshaling of primitive types.
+func TestMustMarshal_SimpleTypes(t *testing.T) {
+	tests := map[string]struct {
+		input    any
+		expected string
+	}{
+		"integer":        {42, "42"},
+		"negative int":   {-100, "-100"},
+		"zero":           {0, "0"},
+		"string":         {"hello", `"hello"`},
+		"empty string":   {"", `""`},
+		"boolean true":   {true, "true"},
+		"boolean false":  {false, "false"},
+		"float":          {3.14, "3.14"},
+		"negative float": {-2.5, "-2.5"},
+	}
+
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			result := MustJSONMarshal(testCase.input)
+
+			require.NotNil(t, result)
+			assert.JSONEq(t, testCase.expected, string(result))
+		})
+	}
+}
+
+// TestMustMarshal_Structs tests marshaling of structs with JSON tags.
+func TestMustMarshal_Structs(t *testing.T) {
+	type SimpleStruct struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	type NestedStruct struct {
+		ID     string       `json:"id"`
+		Simple SimpleStruct `json:"simple"`
+	}
+
+	tests := map[string]struct {
+		input    any
+		expected string
+	}{
+		"simple struct": {
+			SimpleStruct{Name: "test", Value: 123},
+			`{"name":"test","value":123}`,
+		},
+		"struct with empty values": {
+			SimpleStruct{},
+			`{"name":"","value":0}`,
+		},
+		"nested struct": {
+			NestedStruct{
+				ID:     "nested-1",
+				Simple: SimpleStruct{Name: "inner", Value: 456},
+			},
+			`{"id":"nested-1","simple":{"name":"inner","value":456}}`,
+		},
+	}
+
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			result := MustJSONMarshal(testCase.input)
+
+			require.NotNil(t, result)
+			assert.JSONEq(t, testCase.expected, string(result))
+		})
+	}
+}
+
+// TestMustMarshal_Collections tests marshaling of slices, arrays, and maps.
+func TestMustMarshal_Collections(t *testing.T) {
+	tests := map[string]struct {
+		input    any
+		expected string
+	}{
+		"int slice": {
+			[]int{1, 2, 3},
+			`[1,2,3]`,
+		},
+		"empty slice": {
+			[]string{},
+			`[]`,
+		},
+		"string array": {
+			[3]string{"a", "b", "c"},
+			`["a","b","c"]`,
+		},
+		"map string to int": {
+			map[string]int{"one": 1, "two": 2},
+			`{"one":1,"two":2}`,
+		},
+		"empty map": {
+			map[string]string{},
+			`{}`,
+		},
+		"nested slice": {
+			[][]int{{1, 2}, {3, 4}},
+			`[[1,2],[3,4]]`,
+		},
+	}
+
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			result := MustJSONMarshal(testCase.input)
+
+			require.NotNil(t, result)
+			assert.JSONEq(t, testCase.expected, string(result))
+		})
+	}
+}
+
+// TestMustMarshal_SpecialValues tests marshaling of nil, zero values, and edge cases.
+func TestMustMarshal_SpecialValues(t *testing.T) {
+	tests := map[string]struct {
+		input    any
+		expected string
+	}{
+		"nil slice": {
+			([]int)(nil),
+			`null`,
+		},
+		"nil map": {
+			(map[string]int)(nil),
+			`null`,
+		},
+		"nil pointer": {
+			(*string)(nil),
+			`null`,
+		},
+		"pointer to string": {
+			jsonschema.Ptr("test"),
+			`"test"`,
+		},
+		"pointer to int": {
+			jsonschema.Ptr(42),
+			`42`,
+		},
+	}
+
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			result := MustJSONMarshal(testCase.input)
+
+			require.NotNil(t, result)
+			assert.JSONEq(t, testCase.expected, string(result))
+		})
+	}
+}
+
+func TestMustMarshal_Failure(t *testing.T) {
+	if os.Getenv("CRASH_MustMarshal") == "true" {
+		MustJSONMarshal(func() {})
+
+		return
+	}
+
+	// Run the test in a subprocess.
+	cmd := exec.CommandContext(t.Context(), "go", "test", "-test.run=TestMustMarshal_Failure")
+
+	cmd.Env = append(os.Environ(), "CRASH_MustMarshal=true")
+	err := cmd.Run()
+	require.Error(t, err)
+
+	exitState := &exec.ExitError{}
+	correctType := errors.As(err, &exitState)
+	require.True(t, correctType)
+	assert.Equal(t, 1, exitState.ExitCode())
+}


### PR DESCRIPTION
### Description

This PR is adding implementation of list clusters tool.

Input parameters support offset and limit. Unfortunately StackRox API does not support paging for `/v1/clusters` endpoint. So paging is done on a client side within the MCP server.

For validation we are using JSON schema. Defining schema is not ideal, so the processes that schema is defined from struct with additional configuration of defaults and validation values.

### Validation

- [x] Build and test it against demo staging with MCP inspector
- [x] Test with LLM
