### PR TITLE
chore(tweak): Tweak tool name and description

### DIFF
--- a/internal/toolsets/vulnerability/clusters.go
+++ b/internal/toolsets/vulnerability/clusters.go
@@ -47,10 +47,10 @@ type getClustersForCVETool struct {
 	client *client.Client
 }
 
-// NewGetClustersForCVETool creates a new get_clusters_for_cve tool.
+// NewGetClustersForCVETool creates a new get_clusters_with_orchestrator_cve tool.
 func NewGetClustersForCVETool(c *client.Client) toolsets.Tool {
 	return &getClustersForCVETool{
-		name:   "get_clusters_for_cve",
+		name:   "get_clusters_with_orchestrator_cve",
 		client: c,
 	}
 }
@@ -68,8 +68,12 @@ func (t *getClustersForCVETool) GetName() string {
 // GetTool returns the MCP Tool definition.
 func (t *getClustersForCVETool) GetTool() *mcp.Tool {
 	return &mcp.Tool{
-		Name:        t.name,
-		Description: "Get list of clusters affected by a specific CVE",
+		Name: t.name,
+		Description: "Get list of clusters where a specified CVE is detected in Kubernetes orchestrator components" +
+			" (kube-apiserver, kubelet, etcd, etc.)." +
+			" Returns clusters where the Kubernetes infrastructure itself has the vulnerability." +
+			" For comprehensive CVE analysis, also check get_deployments_for_cve (application workloads)" +
+			" and get_nodes_for_cve (node OS packages).",
 		InputSchema: getClustersForCVEInputSchema(),
 	}
 }
@@ -87,7 +91,8 @@ func getClustersForCVEInputSchema() *jsonschema.Schema {
 	schema.Required = []string{"cveName"}
 
 	schema.Properties["cveName"].Description = "CVE name to filter clusters (e.g., CVE-2021-44228)"
-	schema.Properties["filterClusterId"].Description = "Optional cluster ID to verify if a specific cluster is affected"
+	schema.Properties["filterClusterId"].Description = "Optional cluster ID to verify if a specified CVE" +
+		" is detected on that cluster"
 
 	return schema
 }

--- a/internal/toolsets/vulnerability/clusters_test.go
+++ b/internal/toolsets/vulnerability/clusters_test.go
@@ -17,14 +17,14 @@ import (
 func TestNewGetClustersForCVETool(t *testing.T) {
 	tool := NewGetClustersForCVETool(&client.Client{})
 	require.NotNil(t, tool)
-	assert.Equal(t, "get_clusters_for_cve", tool.GetName())
+	assert.Equal(t, "get_clusters_with_orchestrator_cve", tool.GetName())
 }
 
 func TestGetClustersForCVETool_IsReadOnly(t *testing.T) {
 	c := &client.Client{}
 	tool := NewGetClustersForCVETool(c)
 
-	assert.True(t, tool.IsReadOnly(), "get_clusters_for_cve should be read-only")
+	assert.True(t, tool.IsReadOnly(), "get_clusters_with_orchestrator_cve should be read-only")
 }
 
 func TestGetClustersForCVETool_GetTool(t *testing.T) {
@@ -34,8 +34,8 @@ func TestGetClustersForCVETool_GetTool(t *testing.T) {
 	mcpTool := tool.GetTool()
 
 	require.NotNil(t, mcpTool)
-	assert.Equal(t, "get_clusters_for_cve", mcpTool.Name)
-	assert.Contains(t, mcpTool.Description, "clusters affected")
+	assert.Equal(t, "get_clusters_with_orchestrator_cve", mcpTool.Name)
+	assert.Contains(t, mcpTool.Description, "clusters where a specified CVE is detected")
 	assert.NotNil(t, mcpTool.InputSchema)
 }
 

--- a/internal/toolsets/vulnerability/deployments.go
+++ b/internal/toolsets/vulnerability/deployments.go
@@ -92,8 +92,11 @@ func (t *getDeploymentsForCVETool) GetName() string {
 // GetTool returns the MCP Tool definition.
 func (t *getDeploymentsForCVETool) GetTool() *mcp.Tool {
 	return &mcp.Tool{
-		Name:        t.name,
-		Description: "Get list of deployments affected by a specific CVE",
+		Name: t.name,
+		Description: "Get list of deployments where a specified CVE is detected in application" +
+			" or platform container images. Checks user workloads for vulnerabilities." +
+			" For complete CVE analysis, also check get_clusters_with_orchestrator_cve (Kubernetes components)" +
+			" and get_nodes_for_cve (node OS).",
 		InputSchema: getDeploymentsForCVEInputSchema(),
 	}
 }

--- a/internal/toolsets/vulnerability/nodes.go
+++ b/internal/toolsets/vulnerability/nodes.go
@@ -72,8 +72,11 @@ func (t *getNodesForCVETool) GetName() string {
 // GetTool returns the MCP Tool definition.
 func (t *getNodesForCVETool) GetTool() *mcp.Tool {
 	return &mcp.Tool{
-		Name:        t.name,
-		Description: "Get aggregated node groups affected by a specific CVE, grouped by cluster and operating system image",
+		Name: t.name,
+		Description: "Get aggregated node groups where a specified CVE is detected in node operating system packages" +
+			", grouped by cluster and OS image. Checks OS-level vulnerabilities on cluster nodes." +
+			" For comprehensive CVE coverage, also use get_clusters_with_orchestrator_cve (K8s components)" +
+			" and get_deployments_for_cve (workloads).",
 		InputSchema: getNodesForCVEInputSchema(),
 	}
 }

--- a/internal/toolsets/vulnerability/toolset_test.go
+++ b/internal/toolsets/vulnerability/toolset_test.go
@@ -41,7 +41,7 @@ func TestToolset_IsEnabled_True(t *testing.T) {
 	require.Len(t, tools, 3, "Should have all vulnerability tools")
 	assert.Equal(t, "get_deployments_for_cve", tools[0].GetName())
 	assert.Equal(t, "get_nodes_for_cve", tools[1].GetName())
-	assert.Equal(t, "get_clusters_for_cve", tools[2].GetName())
+	assert.Equal(t, "get_clusters_with_orchestrator_cve", tools[2].GetName())
 }
 
 func TestToolset_IsEnabled_False(t *testing.T) {


### PR DESCRIPTION
### Description

This PR changes tool descriptions and names to improve understanding of tools by LLMs.

We had issues like this:
- if we use word "clusters" or "my clusters" - LLM would use only "get_clusters_for_cve" tool. This tool returns only CVE related to orchestrator components, and we expect that everything on "a cluster" is taken into consideration.

After changes introduced there. Prompts that didn't perform as expect, now work as expected.

An example:
Prompt: "Is this CVE-2021-31805 affecting my clusters?"
Before: it only used "get_clusters_for_cve" and provided information that "they are not affected"
Now: it uses all 3 tools and provides information that deployments in namespaces are affected.

### Validation

- [x] Test with LLM

