### PR TITLE
ROX-31489: Add Lightspeed integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Run the server:
 ./stackrox-mcp --config=examples/config-read-only.yaml
 
 # Or using environment variables only
-export STACKROX_MCP__CENTRAL__URL=central.stackrox:8443
+export STACKROX_MCP__CENTRAL__URL=central.stackrox:443
 export STACKROX_MCP__TOOLS__VULNERABILITY__ENABLED=true
 ./stackrox-mcp
 ```
@@ -57,7 +57,7 @@ Note the double underscore (`__`) separator between sections and keys.
 #### Examples
 
 ```bash
-export STACKROX_MCP__CENTRAL__URL=central.stackrox:8443
+export STACKROX_MCP__CENTRAL__URL=central.stackrox:443
 export STACKROX_MCP__GLOBAL__READ_ONLY_TOOLS=true
 export STACKROX_MCP__TOOLS__CONFIG_MANAGER__ENABLED=true
 ```
@@ -70,7 +70,7 @@ Configuration for connecting to StackRox Central.
 
 | Option | Environment Variable | Type | Required | Default | Description |
 |--------|---------------------|------|----------|---------|-------------|
-| `central.url` | `STACKROX_MCP__CENTRAL__URL` | string | Yes | central.stackrox:8443 | URL of StackRox Central instance |
+| `central.url` | `STACKROX_MCP__CENTRAL__URL` | string | Yes | central.stackrox:443 | URL of StackRox Central instance |
 | `central.auth_type` | `STACKROX_MCP__CENTRAL__AUTH_TYPE` | string | No | `passthrough` | Authentication type: `passthrough` (use token from MCP client headers) or `static` (use configured token) |
 | `central.api_token` | `STACKROX_MCP__CENTRAL__API_TOKEN` | string | Conditional | - | API token for static authentication (required when `auth_type` is `static`, must not be set when `passthrough`) |
 | `central.insecure_skip_tls_verify` | `STACKROX_MCP__CENTRAL__INSECURE_SKIP_TLS_VERIFY` | bool | No | `false` | Skip TLS certificate verification (use only for testing) |
@@ -130,7 +130,7 @@ Start the server with a configuration file:
 Or using environment variables:
 
 ```bash
-export STACKROX_MCP__CENTRAL__URL="central.example.com:8443"
+export STACKROX_MCP__CENTRAL__URL="central.example.com:443"
 export STACKROX_MCP__TOOLS__VULNERABILITY__ENABLED="true"
 ./stackrox-mcp
 ```
@@ -287,7 +287,7 @@ Deploy the StackRox MCP server to Kubernetes or OpenShift clusters using Helm.
 helm install stackrox-mcp charts/stackrox-mcp \
   --namespace stackrox-mcp \
   --create-namespace \
-  --set config.central.url=central.stackrox:8443
+  --set config.central.url=central.stackrox:443
 ```
 
 **With custom values file:**
@@ -315,7 +315,7 @@ helm install stackrox-mcp charts/stackrox-mcp \
 helm install stackrox-mcp charts/stackrox-mcp \
   --namespace stackrox-mcp \
   --create-namespace \
-  --set config.central.url=central.stackrox:8443 \
+  --set config.central.url=central.stackrox:443 \
   --set openshift.route.host=stackrox-mcp.apps.example.com
 ```
 
@@ -344,6 +344,12 @@ For complete configuration options including:
 - OpenShift-specific configuration
 
 See the [Helm Chart README](charts/stackrox-mcp/README.md).
+
+### Integrations
+
+**OpenShift Lightspeed Integration:**
+
+For integrating StackRox MCP with OpenShift Lightspeed, see the [OpenShift Lightspeed Integration Guide](docs/lightspeed-integration.md).
 
 ## Development
 

--- a/charts/stackrox-mcp/README.md
+++ b/charts/stackrox-mcp/README.md
@@ -151,7 +151,7 @@ The following table lists the configurable parameters of the StackRox MCP chart 
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `config.central.url` | StackRox Central URL | `central.stackrox:8443` |
+| `config.central.url` | StackRox Central URL | `central.stackrox:443` |
 | `config.central.insecureSkipTLSVerify` | Skip TLS verification (testing only) | `false` |
 | `config.central.forceHTTP1` | Force HTTP/1 bridge | `false` |
 | `config.central.requestTimeout` | Request timeout | `30s` |
@@ -188,7 +188,7 @@ The following table lists the configurable parameters of the StackRox MCP chart 
 ```yaml
 config:
   central:
-    url: "central.stackrox:8443"
+    url: "central.stackrox:443"
 ```
 
 ### OpenShift Deployment
@@ -208,7 +208,7 @@ openshift:
 
 config:
   central:
-    url: "central.stackrox:8443"
+    url: "central.stackrox:443"
 ```
 
 **OpenShift Security Context Constraints (SCC):**
@@ -245,7 +245,7 @@ affinity:
 
 config:
   central:
-    url: "central.stackrox:8443"
+    url: "central.stackrox:443"
 ```
 
 ## Configuration Loading
@@ -299,7 +299,7 @@ Test the health endpoint:
 
 ```bash
 kubectl run -i --tty --rm debug --image=curlimages/curl --restart=Never -- \
-  curl http://stackrox-mcp.stackrox-mcp.svc.cluster.local:8080/health
+  curl http://stackrox-mcp.stackrox-mcp:8080/health
 ```
 
 Expected response: `{"status":"ok"}`

--- a/charts/stackrox-mcp/templates/NOTES.txt
+++ b/charts/stackrox-mcp/templates/NOTES.txt
@@ -17,12 +17,11 @@ StackRox MCP Server Configuration:
    - Configuration Manager: {{ .Values.config.tools.configManager.enabled | ternary "ENABLED" "DISABLED" }}
 
 3. The service is available at:
+   Kubernetes service: {{ include "stackrox-mcp.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}
 {{- if eq (include "stackrox-mcp.isOpenshift" .) "true" }}
    Openshift route: kubectl get route --namespace {{ .Release.Namespace }} {{ include "stackrox-mcp.fullname" . }}
-{{- else }}
-   Kubernetes service: {{ include "stackrox-mcp.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
 {{- end }}
 
 To test connectivity:
   $ kubectl run -i --tty --rm debug --image=curlimages/curl --restart=Never -- \
-    curl http://{{ include "stackrox-mcp.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/health
+    curl http://{{ include "stackrox-mcp.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}/health

--- a/charts/stackrox-mcp/values.yaml
+++ b/charts/stackrox-mcp/values.yaml
@@ -121,7 +121,7 @@ config:
   # Central connection configuration
   central:
     # URL of StackRox Central instance (required)
-    url: "central.stackrox:8443"
+    url: "central.stackrox:443"
 
     # Skip TLS certificate verification (default: false)
     # WARNING: Only use for testing in non-production environments

--- a/cmd/stackrox-mcp/main.go
+++ b/cmd/stackrox-mcp/main.go
@@ -67,7 +67,7 @@ func main() {
 		cancel()
 	}()
 
-	slog.Info("Starting Stackrox MCP server")
+	slog.Info("Starting StackRox MCP server")
 
 	if err := srv.Start(ctx); err != nil {
 		logging.Fatal("Server error", err)

--- a/docs/lightspeed-integration.md
+++ b/docs/lightspeed-integration.md
@@ -1,0 +1,68 @@
+# Guide for Setting Up StackRox MCP OpenShift Lightspeed Integration
+
+Guide tested with OpenShift Lightspeed version `1.0.8`.
+
+### 1. Set Up OpenShift Lightspeed
+- Set up your OpenShift Lightspeed integration with a large language model (LLM) service. Detailed documentation can be found in the [Red Hat OpenShift Lightspeed Configuration Guide](https://docs.redhat.com/en/documentation/red_hat_openshift_lightspeed/1.0/html/configure/ols-configuring-openshift-lightspeed).
+- After OpenShift Lightspeed integration with the LLM is configured and tested, you can continue with StackRox MCP setup.
+
+### 2. Set Up StackRox MCP
+- Install StackRox MCP with Helm:
+    ```bash
+    # Create temp directory and checkout repository with Helm chart.
+    tmp_stackrox_mcp_dir="stackrox-mcp-${RANDOM}"
+    git clone --depth 1 --branch main https://github.com/stackrox/stackrox-mcp.git "${tmp_stackrox_mcp_dir}"
+
+    # Assuming that StackRox Central is installed on the same cluster in "stackrox" namespace.
+    helm install stackrox-mcp "${tmp_stackrox_mcp_dir}/charts/stackrox-mcp" --namespace stackrox-mcp --create-namespace
+
+    # Delete temp directory.
+    rm -rf "${tmp_stackrox_mcp_dir}"
+    ```
+
+    > **Note:** For advanced helm chart configuration options, see the [StackRox MCP Helm Chart README](../charts/stackrox-mcp/README.md). For OpenShift-specific deployment settings, refer to the [OpenShift Deployment](../charts/stackrox-mcp/README.md#openshift-deployment) section.
+
+- Verify the MCP server is running:
+    ```bash
+    kubectl run -i --tty --rm debug --image=curlimages/curl --restart=Never -- \
+      curl http://stackrox-mcp.stackrox-mcp:8080/health
+    ```
+    You should get `{"status":"ok"}` as a response.
+
+### 3. Set Up Integration of StackRox MCP with OpenShift Lightspeed
+- Create an API token in StackRox Central with appropriate permissions.
+- Create Authorization Header Secret
+  - Create a Base64 value for the authorization header secret:
+    ```bash
+    stackrox_api_token="<StackRox API Token>"
+    echo -n "Bearer ${stackrox_api_token}" | base64
+    ```
+  - Create secret `stackrox-mcp-authorization-header` in the `openshift-lightspeed` namespace:
+    ```yaml
+    kind: Secret
+    apiVersion: v1
+    metadata:
+      name: stackrox-mcp-authorization-header
+      namespace: openshift-lightspeed
+    data:
+      header: "<Base64 value for authorization header>"
+    type: Opaque
+    ```
+- Configure OpenShift Lightspeed by editing the `OLSConfig` configuration for your OpenShift Lightspeed installation and add this section to `spec`:
+    ```yaml
+      featureGates:
+        - MCPServer
+      mcpServers:
+        - name: stackrox-mcp
+          streamableHTTP:
+            enableSSE: false
+            headers:
+              authorization: stackrox-mcp-authorization-header
+            sseReadTimeout: 30
+            timeout: 60
+            url: 'http://stackrox-mcp.stackrox-mcp:8080/mcp'
+    ```
+- After completing the setup, test your integration with a simple prompt: "List all clusters secured by StackRox"
+
+### Troubleshooting
+If you encounter issues, refer to the [Troubleshooting](../charts/stackrox-mcp/README.md#troubleshooting) section in the Helm chart documentation.

--- a/examples/config-read-only.yaml
+++ b/examples/config-read-only.yaml
@@ -10,16 +10,16 @@
 # Naming convention: STACKROX_MCP__SECTION__KEY
 # Example:
 #   central:
-#     url: central.stackrox:8443
+#     url: central.stackrox:443
 #
 # Can be overridden with:
-#   STACKROX_MCP__CENTRAL__URL=central.stackrox:8443
+#   STACKROX_MCP__CENTRAL__URL=central.stackrox:443
 
 # Central connection configuration
 central:
-  # Central URL (required, default: central.stackrox:8443)
+  # Central URL (required, default: central.stackrox:443)
   # The URL of your StackRox Central instance
-  url: central.stackrox:8443
+  url: central.stackrox:443
 
   # Authentication type (optional, default: passthrough)
   # Options: "passthrough" or "static"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,7 +130,7 @@ func LoadConfig(configPath string) (*Config, error) {
 
 // setDefaults sets default values for configuration.
 func setDefaults(viper *viper.Viper) {
-	viper.SetDefault("central.url", "central.stackrox:8443")
+	viper.SetDefault("central.url", "central.stackrox:443")
 	viper.SetDefault("central.auth_type", "passthrough")
 	viper.SetDefault("central.api_token", "")
 	viper.SetDefault("central.insecure_skip_tls_verify", false)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -130,7 +130,7 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, "central.stackrox:8443", cfg.Central.URL)
+	assert.Equal(t, "central.stackrox:443", cfg.Central.URL)
 	assert.False(t, cfg.Central.InsecureSkipTLSVerify)
 	assert.False(t, cfg.Central.ForceHTTP1)
 	assert.True(t, cfg.Global.ReadOnlyTools)


### PR DESCRIPTION
### Description

This PR is adding instruction on how to make integration of StackRox MCP server with OpenShift Lightspeed.

Changes:
- added documentation
- linked documentation from root project README
- (refactoring) Adjusted port in configurations from `8443` to `443`, because that is set by default for Central service - https://github.com/stackrox/stackrox/blob/ce49939b44b24c7d410f933b8227045ee403365c/image/templates/helm/stackrox-central/templates/_central_endpoints.tpl#L5
- Removed `.svc.cluster.local` from outputs where service link is provided. Now we use only `<svc-name>.<namespace>`

### Validation

- [x] manually tested on dev cluster
