### PR TITLE
chore(fix): Fix trusted certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,10 @@ ENV LOG_LEVEL=INFO
 # Set working directory
 WORKDIR /app
 
+# Copy trusted certificates from builder
+COPY --from=builder /etc/pki/ca-trust/extracted/ /etc/pki/ca-trust/extracted/
+COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs/
+
 # Copy binary from builder
 COPY --from=builder /tmp/stackrox-mcp /app/stackrox-mcp
 


### PR DESCRIPTION
### Description

This PR should fix issue with missing trusted certificates in image. Trusted certs are now copied from builder image.

### Validation

- [x] Tested locally on staging demo.

With new image everything works as expected.
With old image, there is an error:
```
{"time":"2026-01-16T17:05:53.92696058Z","level":"INFO","msg":"Request failed, retrying","method":"/v1.ClustersService/GetClusters","attempt":2,"backoff":2000000000,"error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: authentication handshake failed: tls: failed to verify certificate: x509: certificate signed by unknown authority\""}
```
