### PR TITLE
ROX-32640: Add TLS Support

### DIFF
--- a/charts/stackrox-mcp/templates/NOTES.txt
+++ b/charts/stackrox-mcp/templates/NOTES.txt
@@ -24,4 +24,20 @@ StackRox MCP Server Configuration:
 
 To test connectivity:
   $ kubectl run -i --tty --rm debug --image=curlimages/curl --restart=Never -- \
-    curl http://{{ include "stackrox-mcp.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}/health
+    curl -k {{ include "stackrox-mcp.portName" . }}://{{ include "stackrox-mcp.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}/health
+
+{{- if and (eq (include "stackrox-mcp.isOpenshift" .) "true") .Values.config.server.TLSEnabled (ne .Values.openshift.route.tls.termination "reencrypt") }}
+
+WARN: OpenShift route TLS termination should be set to "reencrypt" if TLS encryption is enabled. You should set ".openshift.route.tls.termination" to "reencrypt".
+{{- end }}
+
+{{- if .Values.config.server.TLSEnabled }}
+
+TLS Configuration:
+  Secret Name: {{ include "stackrox-mcp.tlsSecretName" . }}
+  {{- if .Values.tlsSecret.existingSecretName }}
+  Status: Using existing secret "{{ .Values.tlsSecret.existingSecretName }}"
+  {{- else }}
+  Status: Generated secret with provided certificates
+  {{- end }}
+{{- end }}

--- a/charts/stackrox-mcp/templates/_helpers.tpl
+++ b/charts/stackrox-mcp/templates/_helpers.tpl
@@ -62,3 +62,21 @@ Detect if running on OpenShift
 {{- define "stackrox-mcp.isOpenshift" -}}
 {{- .Capabilities.APIVersions.Has "route.openshift.io/v1" -}}
 {{- end }}
+
+{{/*
+Define application port name
+*/}}
+{{- define "stackrox-mcp.portName" -}}
+{{ if .Values.config.server.TLSEnabled }}https{{ else }}http{{ end }}
+{{- end }}
+
+{{/*
+TLS Secret name - returns existingSecretName if set, otherwise generates name
+*/}}
+{{- define "stackrox-mcp.tlsSecretName" -}}
+{{- if .Values.tlsSecret.existingSecretName }}
+{{- .Values.tlsSecret.existingSecretName }}
+{{- else }}
+{{- include "stackrox-mcp.fullname" . }}-tls
+{{- end }}
+{{- end }}

--- a/charts/stackrox-mcp/templates/configmap.yaml
+++ b/charts/stackrox-mcp/templates/configmap.yaml
@@ -22,11 +22,18 @@ data:
     global:
       read_only_tools: {{ .Values.config.global.readOnlyTools }}
 
-    # HTTP server configuration
+    # HTTP/HTTPS server configuration
     server:
       type: "streamable-http"
       address: {{ .Values.config.server.address | quote }}
       port: {{ .Values.config.server.port }}
+      {{- if .Values.config.server.TLSEnabled }}
+      tls_enabled: true
+      tls_cert_path: {{ .Values.config.server.TLSCertPath | quote }}
+      tls_key_path: {{ .Values.config.server.TLSKeyPath | quote }}
+      {{- else }}
+      tls_enabled: false
+      {{- end }}
 
     # MCP tools configuration
     {{- if not (or .Values.config.tools.vulnerability.enabled .Values.config.tools.configManager.enabled) }}

--- a/charts/stackrox-mcp/templates/deployment.yaml
+++ b/charts/stackrox-mcp/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
           - --config
           - /config/config.yaml
         ports:
-        - name: http
+        - name: {{ include "stackrox-mcp.portName" . }}
           containerPort: {{ .Values.config.server.port }}
           protocol: TCP
         {{- with .Values.extraEnv }}
@@ -74,11 +74,31 @@ spec:
         {{- end }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
-          {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 10 }}
+          httpGet:
+            path: /health
+            port: {{ include "stackrox-mcp.portName" . }}
+            {{- if .Values.config.server.TLSEnabled }}
+            scheme: HTTPS
+            {{- end }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         {{- end }}
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
-          {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 10 }}
+          httpGet:
+            path: /health
+            port: {{ include "stackrox-mcp.portName" . }}
+            {{- if .Values.config.server.TLSEnabled }}
+            scheme: HTTPS
+            {{- end }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
@@ -86,10 +106,21 @@ spec:
         - name: config
           mountPath: /config
           readOnly: true
+        {{- if .Values.config.server.TLSEnabled }}
+        - name: tls-certs
+          mountPath: /certs
+          readOnly: true
+        {{- end }}
       volumes:
       - name: config
         configMap:
           name: {{ include "stackrox-mcp.configMapName" . }}
+      {{- if .Values.config.server.TLSEnabled }}
+      - name: tls-certs
+        secret:
+          secretName: {{ include "stackrox-mcp.tlsSecretName" . }}
+          defaultMode: 0440
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/stackrox-mcp/templates/route.yaml
+++ b/charts/stackrox-mcp/templates/route.yaml
@@ -20,10 +20,13 @@ spec:
     kind: Service
     name: {{ include "stackrox-mcp.fullname" . }}
   port:
-    targetPort: http
+    targetPort: {{ include "stackrox-mcp.portName" . }}
   {{- if .Values.openshift.route.tls.enabled }}
   tls:
     termination: {{ .Values.openshift.route.tls.termination }}
     insecureEdgeTerminationPolicy: {{ .Values.openshift.route.tls.insecureEdgeTerminationPolicy }}
+    {{- if and .Values.config.server.TLSEnabled .Values.openshift.route.tls.destinationCACertificate }}
+    destinationCACertificate: {{ .Values.openshift.route.tls.destinationCACertificate | quote }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/stackrox-mcp/templates/secret.yaml
+++ b/charts/stackrox-mcp/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.config.server.TLSEnabled (not .Values.tlsSecret.existingSecretName) }}
+{{- if not (and .Values.tlsSecret.cert .Values.tlsSecret.key) }}
+{{- fail "Both tlsSecret.cert and tlsSecret.key must be provided together" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "stackrox-mcp.tlsSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "stackrox-mcp.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.tlsSecret.cert | b64enc }}
+  tls.key: {{ .Values.tlsSecret.key | b64enc }}
+{{- end }}

--- a/charts/stackrox-mcp/templates/service.yaml
+++ b/charts/stackrox-mcp/templates/service.yaml
@@ -11,10 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  sessionAffinity: ClientIP
+  {{- end }}
   ports:
   - port: {{ .Values.service.port }}
-    targetPort: {{ .Values.service.targetPort }}
+    targetPort: {{ include "stackrox-mcp.portName" . }}
     protocol: TCP
-    name: http
+    name: {{ include "stackrox-mcp.portName" . }}
   selector:
     {{- include "stackrox-mcp.selectorLabels" . | nindent 4 }}

--- a/charts/stackrox-mcp/values.yaml
+++ b/charts/stackrox-mcp/values.yaml
@@ -56,10 +56,18 @@ securityContext:
 
 # Service configuration
 service:
-  type: ClusterIP
-  port: 8080
-  targetPort: 8080
+  type: LoadBalancer
+  port: 443
   annotations: {}
+
+# TLS Secret configuration
+tlsSecret:
+  # Existing secret name can be provided if already existing secret with certificate and key is used
+  existingSecretName: ""
+  # Server TLS Certificate (PEM format)
+  cert: ""
+  # Server TLS Private Key (PEM format)
+  key: ""
 
 # Resource limits and requests
 resources:
@@ -73,9 +81,6 @@ resources:
 # Liveness probe configuration
 livenessProbe:
   enabled: true
-  httpGet:
-    path: /health
-    port: http
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
@@ -85,9 +90,6 @@ livenessProbe:
 # Readiness probe configuration
 readinessProbe:
   enabled: true
-  httpGet:
-    path: /health
-    port: http
   initialDelaySeconds: 5
   periodSeconds: 5
   timeoutSeconds: 3
@@ -113,8 +115,15 @@ openshift:
     host: ""
     tls:
       enabled: true
-      termination: edge
+
+      # Termination type: 'reencrypt' for end-to-end TLS, 'edge' for TLS termination at router
+      termination: reencrypt
       insecureEdgeTerminationPolicy: Redirect
+
+      # Destination CA certificate (optional)
+      # This is the CA that signed the pod's certificate
+      # If not provided, router will use its own CA bundle to verify pod certificate
+      destinationCACertificate: ""
 
 # StackRox MCP Configuration
 config:
@@ -148,13 +157,21 @@ config:
     # Allow only read-only MCP tools (default: true)
     readOnlyTools: true
 
-  # HTTP server configuration
+  # HTTP/HTTPS server configuration
   server:
     # Server listen address (default: 0.0.0.0)
     address: "0.0.0.0"
 
-    # Server listen port (1-65535, default: 8080)
-    port: 8080
+    # Server listen port (1-65535, default: 8443 for HTTPS, 8080 for HTTP)
+    port: 8443
+
+    # Enable TLS/HTTPS on the application server (default: true)
+    # When enabled, provides end-to-end encryption from client to pod
+    TLSEnabled: true
+
+    # Mount paths for certificates inside the container
+    TLSCertPath: "/certs/tls.crt"
+    TLSKeyPath: "/certs/tls.key"
 
   # MCP tools configuration
   # At least one tool must be enabled

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,11 @@ type ServerConfig struct {
 	Type    serverType `mapstructure:"type"`
 	Address string     `mapstructure:"address"`
 	Port    int        `mapstructure:"port"`
+
+	// TLS configuration
+	TLSEnabled  bool   `mapstructure:"tls_enabled"`
+	TLSCertPath string `mapstructure:"tls_cert_path"`
+	TLSKeyPath  string `mapstructure:"tls_key_path"`
 }
 
 // ToolsConfig contains configuration for individual MCP tools.
@@ -146,6 +151,9 @@ func setDefaults(viper *viper.Viper) {
 	viper.SetDefault("server.address", "0.0.0.0")
 	viper.SetDefault("server.port", defaultPort)
 	viper.SetDefault("server.type", ServerTypeStreamableHTTP)
+	viper.SetDefault("server.tls_enabled", false)
+	viper.SetDefault("server.tls_cert_path", "/certs/tls.crt")
+	viper.SetDefault("server.tls_key_path", "/certs/tls.key")
 
 	viper.SetDefault("tools.vulnerability.enabled", false)
 	viper.SetDefault("tools.config_manager.enabled", false)
@@ -229,6 +237,16 @@ func (sc *ServerConfig) validate() error {
 
 	if sc.Port < 1 || sc.Port > 65535 {
 		return errors.New("server.port must be between 1 and 65535")
+	}
+
+	if sc.TLSEnabled {
+		if sc.TLSCertPath == "" {
+			return errors.New("server.tls_cert_path is required when TLS is enabled")
+		}
+
+		if sc.TLSKeyPath == "" {
+			return errors.New("server.tls_key_path is required when TLS is enabled")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
### Description

This PR is adding support for TLS encryption (https).

Changes:
- added config for TLS certificate (cert) and key
- modified Helm to support providing of cert and key
- documented instructions for helm chart
- added support to provide secret with cert and key managed externally (not created by helm)
- added support for OpenShift route to do TLS termination (or passthrough) - configurable

### Validation

- [x] deploy everything with helm:
```
helm install stackrox-mcp charts/stackrox-mcp \
  --namespace stackrox-mcp \
  --create-namespace \
  --set-file tlsSecret.caCert=<Cert file> \
  --set-file tlsSecret.caKey=<Key file> \
  --set-file openshift.route.tls.destinationCACertificate=<Cert file> \
  --set image.tag=cc8bfba \
  --set config.central.url=<Central URL>
```
**Note:** `cc8bfba` - tag is from one of previous builds on this branch where https support is added to application
- [x] test with claude code for `https`
- [x] deploy in `http` mode with helm:
```
helm install stackrox-mcp charts/stackrox-mcp \
  --namespace stackrox-mcp \
  --create-namespace \
  --set config.server.TLSEnabled=false \
  --set config.server.port=8080 \
  --set openshift.route.tls.termination=edge \
  --set service.type=ClusterIP \
  --set image.tag=cc8bfba \
  --set config.central.url=<Central URL>
```
- [x] test with claude code for `http`