### PR TITLE
ROX-32886: Add support for branding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ FROM --platform=$BUILDPLATFORM $GOLANG_BUILDER AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
-# Build arguments for application version
+# Build arguments for application version and branding
 ARG VERSION=dev
+ARG SERVER_NAME=stackrox-mcp
+ARG PRODUCT_DISPLAY_NAME=StackRox
 
 # Set working directory
 WORKDIR /workspace
@@ -33,7 +35,10 @@ COPY . .
 # Output to "/tmp" directory, because user can not copy built binary to "/workspace"
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build \
-    -ldflags="-w -s" \
+    -ldflags="-w -s \
+      -X 'github.com/stackrox/stackrox-mcp/internal/config.version=${VERSION}' \
+      -X 'github.com/stackrox/stackrox-mcp/internal/config.serverName=${SERVER_NAME}' \
+      -X 'github.com/stackrox/stackrox-mcp/internal/config.productDisplayName=${PRODUCT_DISPLAY_NAME}'" \
     -trimpath \
     -o /tmp/stackrox-mcp \
     ./cmd/stackrox-mcp

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,15 @@ GOCLEAN=$(GOCMD) clean
 # Set the container runtime command - prefer podman, fallback to docker
 DOCKER_CMD = $(shell command -v podman >/dev/null 2>&1 && echo podman || echo docker)
 
+# Branding can be overridden for Red Hat builds
+SERVER_NAME?=stackrox-mcp
+PRODUCT_DISPLAY_NAME?=StackRox
+
 # Build flags
-LDFLAGS=-ldflags "-X github.com/stackrox/stackrox-mcp/internal/server.version=$(VERSION)"
+LDFLAGS=-ldflags "\
+  -X 'github.com/stackrox/stackrox-mcp/internal/config.version=$(VERSION)' \
+  -X 'github.com/stackrox/stackrox-mcp/internal/config.serverName=$(SERVER_NAME)' \
+  -X 'github.com/stackrox/stackrox-mcp/internal/config.productDisplayName=$(PRODUCT_DISPLAY_NAME)'"
 
 # Coverage files
 COVERAGE_OUT=coverage.out
@@ -41,7 +48,9 @@ build: ## Build the binary
 .PHONY: image
 image: ## Build the docker image
 	$(DOCKER_CMD) build \
-		--build-arg VERSION=$(VERSION) \
+		--build-arg VERSION="$(VERSION)" \
+		--build-arg SERVER_NAME="$(SERVER_NAME)" \
+		--build-arg PRODUCT_DISPLAY_NAME="$(PRODUCT_DISPLAY_NAME)" \
 		-t quay.io/stackrox-io/mcp:$(VERSION) \
 		.
 

--- a/internal/config/branding.go
+++ b/internal/config/branding.go
@@ -1,0 +1,35 @@
+package config
+
+// Branding variables are set at build time via ldflags.
+// Red Hat builds override these defaults:
+//
+//	-X github.com/stackrox/stackrox-mcp/internal/config.serverName=acs-mcp-server
+//	-X github.com/stackrox/stackrox-mcp/internal/config.productDisplayName=Red Hat Advanced Cluster Security (ACS)
+//	-X github.com/stackrox/stackrox-mcp/internal/config.version=<version>
+var (
+	// serverName is the MCP server name reported to clients.
+	//nolint:gochecknoglobals
+	serverName = "stackrox-mcp"
+
+	// productDisplayName is the product name used in tool descriptions.
+	//nolint:gochecknoglobals
+	productDisplayName = "StackRox"
+
+	// version is the application version.
+	version = "dev"
+)
+
+// GetServerName returns the MCP server name.
+func GetServerName() string {
+	return serverName
+}
+
+// GetProductDisplayName returns the product display name used in tool descriptions.
+func GetProductDisplayName() string {
+	return productDisplayName
+}
+
+// GetVersion returns the application version.
+func GetVersion() string {
+	return version
+}

--- a/internal/config/branding_test.go
+++ b/internal/config/branding_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetServerName(t *testing.T) {
+	assert.Equal(t, "stackrox-mcp", GetServerName())
+
+	original := serverName
+
+	t.Cleanup(func() { serverName = original })
+
+	serverName = "acs-mcp-server"
+
+	assert.Equal(t, "acs-mcp-server", GetServerName())
+}
+
+func TestGetProductDisplayName(t *testing.T) {
+	assert.Equal(t, "StackRox", GetProductDisplayName())
+
+	original := productDisplayName
+
+	t.Cleanup(func() { productDisplayName = original })
+
+	productDisplayName = "Red Hat Advanced Cluster Security (ACS)"
+
+	assert.Equal(t, "Red Hat Advanced Cluster Security (ACS)", GetProductDisplayName())
+}
+
+func TestGetVersion(t *testing.T) {
+	assert.Equal(t, "dev", GetVersion())
+
+	original := version
+
+	t.Cleanup(func() { version = original })
+
+	version = "1.2.3"
+
+	assert.Equal(t, "1.2.3", GetVersion())
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,9 +22,6 @@ const (
 	readHeaderTimeout = 5 * time.Second
 )
 
-// version is set at build time via ldflags (ldflags can't modify constants).
-var version = "dev"
-
 // Server represents the MCP HTTP server.
 type Server struct {
 	cfg      *config.Config
@@ -36,8 +33,8 @@ type Server struct {
 func NewServer(cfg *config.Config, registry *toolsets.Registry) *Server {
 	mcpServer := mcp.NewServer(
 		&mcp.Implementation{
-			Name:    "stackrox-mcp",
-			Version: version,
+			Name:    config.GetServerName(),
+			Version: config.GetVersion(),
 		},
 		nil,
 	)

--- a/internal/toolsets/config/tools.go
+++ b/internal/toolsets/config/tools.go
@@ -9,6 +9,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/stackrox-mcp/internal/client"
 	"github.com/stackrox/stackrox-mcp/internal/client/auth"
+	"github.com/stackrox/stackrox-mcp/internal/config"
 	"github.com/stackrox/stackrox-mcp/internal/logging"
 	"github.com/stackrox/stackrox-mcp/internal/toolsets"
 )
@@ -69,8 +70,8 @@ func (t *listClustersTool) GetName() string {
 func (t *listClustersTool) GetTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name: t.name,
-		Description: "List all clusters managed by StackRox with their IDs, names, and types." +
-			" Use this tool to get cluster information," +
+		Description: "List all clusters secured by " + config.GetProductDisplayName() +
+			" with their IDs, names, and types. Use this tool to get cluster information," +
 			" or when you need to map a cluster name to its cluster ID for use in other tools.",
 		InputSchema: listClustersInputSchema(),
 	}

--- a/internal/toolsets/vulnerability/clusters.go
+++ b/internal/toolsets/vulnerability/clusters.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/stackrox-mcp/internal/client"
 	"github.com/stackrox/stackrox-mcp/internal/client/auth"
+	"github.com/stackrox/stackrox-mcp/internal/config"
 	"github.com/stackrox/stackrox-mcp/internal/logging"
 	"github.com/stackrox/stackrox-mcp/internal/toolsets"
 )
@@ -74,8 +75,9 @@ func (t *getClustersForCVETool) GetName() string {
 func (t *getClustersForCVETool) GetTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name: t.name,
-		Description: "Get list of clusters where a specified vulnerability" +
-			" is detected in Kubernetes orchestrator components (kube-apiserver, kubelet, etcd, etc.)." +
+		Description: "Get list of clusters secured by " + config.GetProductDisplayName() +
+			" where a specified vulnerability is detected in" +
+			" Kubernetes orchestrator components (kube-apiserver, kubelet, etcd, etc.)." +
 			" Supports CVE, RHSA, RHEA, RHBA identifiers." +
 			" USAGE PATTERNS:" +
 			" 1) When user asks 'Is CVE-X detected in my clusters?' (plural, general question):" +

--- a/internal/toolsets/vulnerability/clusters_test.go
+++ b/internal/toolsets/vulnerability/clusters_test.go
@@ -35,7 +35,7 @@ func TestGetClustersForCVETool_GetTool(t *testing.T) {
 
 	require.NotNil(t, mcpTool)
 	assert.Equal(t, "get_clusters_with_orchestrator_cve", mcpTool.Name)
-	assert.Contains(t, mcpTool.Description, "clusters where")
+	assert.Contains(t, mcpTool.Description, "clusters secured by")
 	assert.Contains(t, mcpTool.Description, "vulnerability is detected")
 	assert.NotNil(t, mcpTool.InputSchema)
 }

--- a/internal/toolsets/vulnerability/deployments.go
+++ b/internal/toolsets/vulnerability/deployments.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/stackrox-mcp/internal/client"
 	"github.com/stackrox/stackrox-mcp/internal/client/auth"
+	"github.com/stackrox/stackrox-mcp/internal/config"
 	"github.com/stackrox/stackrox-mcp/internal/cursor"
 	"github.com/stackrox/stackrox-mcp/internal/logging"
 	"github.com/stackrox/stackrox-mcp/internal/toolsets"
@@ -99,8 +100,8 @@ func (t *getDeploymentsForCVETool) GetName() string {
 func (t *getDeploymentsForCVETool) GetTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name: t.name,
-		Description: "Get list of deployments where a specified vulnerability" +
-			" is detected in application or platform container images." +
+		Description: "Get list of deployments secured by " + config.GetProductDisplayName() +
+			" where a specified vulnerability is detected in application or platform container images." +
 			" Supports CVE, GHSA, and 22+ other vulnerability identifier formats." +
 			" USAGE PATTERNS:" +
 			" 1) When user asks 'Is CVE-X detected in my clusters?' (plural, general question):" +

--- a/internal/toolsets/vulnerability/nodes.go
+++ b/internal/toolsets/vulnerability/nodes.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/stackrox-mcp/internal/client"
 	"github.com/stackrox/stackrox-mcp/internal/client/auth"
+	"github.com/stackrox/stackrox-mcp/internal/config"
 	"github.com/stackrox/stackrox-mcp/internal/logging"
 	"github.com/stackrox/stackrox-mcp/internal/toolsets"
 	"google.golang.org/grpc"
@@ -78,9 +79,9 @@ func (t *getNodesForCVETool) GetName() string {
 func (t *getNodesForCVETool) GetTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name: t.name,
-		Description: "Get aggregated node groups where a specified vulnerability is detected" +
-			" in node operating system packages, grouped by cluster and OS image." +
-			" Supports CVE, RHSA, RHEA, RHBA identifiers." +
+		Description: "Get aggregated node groups secured by " + config.GetProductDisplayName() +
+			" where a specified vulnerability is detected in node operating system packages," +
+			" grouped by cluster and OS image. Supports CVE, RHSA, RHEA, RHBA identifiers." +
 			" USAGE PATTERNS:" +
 			" 1) When user asks 'Is CVE-X detected in my clusters?' (plural, general question):" +
 			" Call ALL THREE CVE tools (get_clusters_with_orchestrator_cve, get_deployments_for_cve, get_nodes_for_cve)" +


### PR DESCRIPTION
### Description

This PR adds support for MCP server branding.

**Changes:**
- added support for server and product name
- consolidated all `-X` ldflags in config package
- fixed Dockerfile to pass flag properly
- added product name to each tool description

### Validation

- [x] unit tests

