### PR TITLE
ROX-32888: Fix eval docs update

### DIFF
--- a/.github/workflows/model-evaluation.yml
+++ b/.github/workflows/model-evaluation.yml
@@ -87,7 +87,11 @@ jobs:
       - name: Download all results
         uses: actions/download-artifact@v8
         with:
-          pattern: eval-results-*
+          # Download all artifacts instead of using pattern matching.
+          # When pattern matches a single artifact, download-artifact extracts
+          # it directly into the path without creating a subdirectory, breaking
+          # the expected path structure. Downloading all artifacts always creates
+          # per-artifact subdirectories.
           path: eval-results
 
       - name: Update model evaluation docs
@@ -101,9 +105,12 @@ jobs:
                 --model-id "${MODEL}" \
                 --results "${RESULTS_FILE}"
             else
-              echo "::warning:: No results found for model ${MODEL}"
+              echo "::warning::No results found for model ${MODEL}"
             fi
           done
+
+      - name: Clean up eval results
+        run: rm -rf eval-results
 
       - name: Check for changes
         id: check-changes


### PR DESCRIPTION
### Description

Fixes the `download-artifact` path issue in the model-evaluation workflow. When `download-artifact@v8` matches a single artifact via `pattern`, it extracts directly into the target path without creating a per-artifact subdirectory, breaking the expected path `eval-results/eval-results-<model>/...`. Fixed by removing the `pattern` parameter so all artifacts are downloaded, which always creates subdirectories.

Also added a cleanup step to remove downloaded artifacts before PR creation so they don't get committed.

### Validation

- [x] `actionlint` passes on the modified workflow file
- [x] Trigger workflow manually via `workflow_dispatch` after merging to verify end-to-end behavior

### AI-assisted development prompts

This PR was developed with AI assistance. Below are the prompts used:

> **Prompt:** "I executed workflow and it failed: 'Warning: No results found for model gpt-5-mini'. Result is properly found."
> **Response:** Investigated the path mismatch between `download-artifact` output and the expected file path in the update script.

> **Prompt:** "Can it be an issue what only one artifact is matched? Docs: 'Note: When downloading a single artifact (by name or ID), it will always be extracted directly to the specified path.'"
> **Response:** Confirmed this is the root cause — single artifact downloads skip subdirectory creation.

> **Prompt:** "As I see, if we would use 'Download All Artifacts' option, then we should not have such problem. Is that correct?"
> **Response:** Confirmed that removing the `pattern` parameter downloads all artifacts and always creates per-artifact subdirectories.

> **Prompt:** "Create task to fix this bug. With option to download all artifacts. We should also document why that solution is used."
> **Response:** Created beads bug task `stackrox-mcp-b2l` with the fix plan.

> **Prompt:** "We need one additional change. After doc is updated, we need to delete eval-results - otherwise, they will end in branch and PR."
> **Response:** Added a cleanup step (`rm -rf eval-results`) before the change detection step to prevent artifacts from being committed.