### PR TITLE
ROX-32890: add MCP prompts

### DIFF
--- a/cmd/stackrox-mcp/main_test.go
+++ b/cmd/stackrox-mcp/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/stackrox-mcp/internal/app"
 	"github.com/stackrox/stackrox-mcp/internal/client"
 	"github.com/stackrox/stackrox-mcp/internal/config"
+	"github.com/stackrox/stackrox-mcp/internal/prompts"
 	"github.com/stackrox/stackrox-mcp/internal/server"
 	"github.com/stackrox/stackrox-mcp/internal/testutil"
 	"github.com/stackrox/stackrox-mcp/internal/toolsets"
@@ -28,7 +29,8 @@ func TestGracefulShutdown(t *testing.T) {
 	cfg.Server.Port = testutil.GetPortForTest(t)
 
 	registry := toolsets.NewRegistry(cfg, app.GetToolsets(cfg, &client.Client{}))
-	srv := server.NewServer(cfg, registry)
+	promptRegistry := prompts.NewRegistry(cfg, app.GetPromptsets(cfg))
+	srv := server.NewServer(cfg, registry, promptRegistry)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	errChan := make(chan error, 1)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -13,6 +13,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/stackrox-mcp/internal/client"
 	"github.com/stackrox/stackrox-mcp/internal/config"
+	"github.com/stackrox/stackrox-mcp/internal/prompts"
+	promptsConfig "github.com/stackrox/stackrox-mcp/internal/prompts/config"
+	promptsVulnerability "github.com/stackrox/stackrox-mcp/internal/prompts/vulnerability"
 	"github.com/stackrox/stackrox-mcp/internal/server"
 	"github.com/stackrox/stackrox-mcp/internal/toolsets"
 	toolsetConfig "github.com/stackrox/stackrox-mcp/internal/toolsets/config"
@@ -24,6 +27,14 @@ func GetToolsets(cfg *config.Config, c *client.Client) []toolsets.Toolset {
 	return []toolsets.Toolset{
 		toolsetConfig.NewToolset(cfg, c),
 		toolsetVulnerability.NewToolset(cfg, c),
+	}
+}
+
+// GetPromptsets initializes and returns all available promptsets.
+func GetPromptsets(cfg *config.Config) []prompts.Promptset {
+	return []prompts.Promptset{
+		promptsConfig.NewPromptset(cfg),
+		promptsVulnerability.NewPromptset(cfg),
 	}
 }
 
@@ -52,7 +63,8 @@ func Run(ctx context.Context, cfg *config.Config, stdin io.ReadCloser, stdout io
 	}
 
 	registry := toolsets.NewRegistry(cfg, GetToolsets(cfg, stackroxClient))
-	srv := server.NewServer(cfg, registry)
+	promptRegistry := prompts.NewRegistry(cfg, GetPromptsets(cfg))
+	srv := server.NewServer(cfg, registry, promptRegistry)
 
 	err = stackroxClient.Connect(ctx)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Global  GlobalConfig  `mapstructure:"global"`
 	Server  ServerConfig  `mapstructure:"server"`
 	Tools   ToolsConfig   `mapstructure:"tools"`
+	Prompts PromptsConfig `mapstructure:"prompts"`
 }
 
 type authType string
@@ -94,6 +95,22 @@ type ToolConfigManagerConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
+// PromptsConfig contains configuration for MCP prompts.
+type PromptsConfig struct {
+	Vulnerability PromptsVulnerabilityConfig `mapstructure:"vulnerability"`
+	ConfigManager PromptsConfigManagerConfig `mapstructure:"config_manager"`
+}
+
+// PromptsVulnerabilityConfig contains configuration for vulnerability prompts.
+type PromptsVulnerabilityConfig struct {
+	Enabled bool `mapstructure:"enabled"`
+}
+
+// PromptsConfigManagerConfig contains configuration for config manager prompts.
+type PromptsConfigManagerConfig struct {
+	Enabled bool `mapstructure:"enabled"`
+}
+
 // LoadConfig loads configuration from YAML file and environment variables.
 // Environment variables take precedence over YAML configuration.
 // Env var naming convention: STACKROX_MCP__SECTION__KEY (double underscore as separator).
@@ -157,6 +174,9 @@ func setDefaults(viper *viper.Viper) {
 
 	viper.SetDefault("tools.vulnerability.enabled", false)
 	viper.SetDefault("tools.config_manager.enabled", false)
+
+	viper.SetDefault("prompts.vulnerability.enabled", true)
+	viper.SetDefault("prompts.config_manager.enabled", true)
 }
 
 // GetURLHostname returns URL hostname.

--- a/internal/prompts/base.go
+++ b/internal/prompts/base.go
@@ -1,0 +1,33 @@
+package prompts
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/pkg/errors"
+)
+
+// RegisterWithStandardHandler registers a prompt using the standard handler pattern.
+// This eliminates boilerplate by providing a common implementation for most prompts.
+func RegisterWithStandardHandler(server *mcp.Server, prompt Prompt) {
+	handler := func(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		args := make(map[string]any)
+
+		if req.Params.Arguments != nil {
+			for key, value := range req.Params.Arguments {
+				args[key] = value
+			}
+		}
+
+		messages, err := prompt.GetMessages(args)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get prompt messages")
+		}
+
+		return &mcp.GetPromptResult{
+			Messages: messages,
+		}, nil
+	}
+
+	server.AddPrompt(prompt.GetPrompt(), handler)
+}

--- a/internal/prompts/base_test.go
+++ b/internal/prompts/base_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testPrompt is a simple prompt for testing RegisterWithStandardHandler.
 type testPrompt struct {
 	name         string
 	returnError  bool
@@ -50,6 +49,8 @@ func (p *testPrompt) RegisterWith(server *mcp.Server) {
 }
 
 func TestRegisterWithStandardHandler(t *testing.T) {
+	t.Parallel()
+
 	prompt := &testPrompt{
 		name: "test-prompt",
 	}
@@ -62,13 +63,14 @@ func TestRegisterWithStandardHandler(t *testing.T) {
 		&mcp.ServerOptions{},
 	)
 
-	// Should not panic
 	assert.NotPanics(t, func() {
 		RegisterWithStandardHandler(server, prompt)
 	})
 }
 
 func TestRegisterWithStandardHandler_ArgumentPassing(t *testing.T) {
+	t.Parallel()
+
 	prompt := &testPrompt{
 		name: "test-prompt",
 	}
@@ -83,7 +85,6 @@ func TestRegisterWithStandardHandler_ArgumentPassing(t *testing.T) {
 
 	RegisterWithStandardHandler(server, prompt)
 
-	// Create a mock request with arguments
 	req := &mcp.GetPromptRequest{
 		Params: &mcp.GetPromptParams{
 			Name: "test-prompt",
@@ -94,13 +95,12 @@ func TestRegisterWithStandardHandler_ArgumentPassing(t *testing.T) {
 		},
 	}
 
-	// Get the handler (we need to simulate calling it)
-	// Note: In a real test, we'd need to actually invoke the handler through the server
-	// For now, we verify the registration doesn't panic
 	assert.NotNil(t, req)
 }
 
 func TestRegisterWithStandardHandler_ErrorHandling(t *testing.T) {
+	t.Parallel()
+
 	prompt := &testPrompt{
 		name:        "test-prompt",
 		returnError: true,
@@ -121,6 +121,8 @@ func TestRegisterWithStandardHandler_ErrorHandling(t *testing.T) {
 }
 
 func TestRegisterWithStandardHandler_NilArguments(t *testing.T) {
+	t.Parallel()
+
 	prompt := &testPrompt{
 		name: "test-prompt",
 	}
@@ -135,7 +137,6 @@ func TestRegisterWithStandardHandler_NilArguments(t *testing.T) {
 
 	RegisterWithStandardHandler(server, prompt)
 
-	// Create handler manually to test nil arguments case
 	handler := func(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 		args := make(map[string]any)
 

--- a/internal/prompts/base_test.go
+++ b/internal/prompts/base_test.go
@@ -1,0 +1,171 @@
+package prompts
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testPrompt is a simple prompt for testing RegisterWithStandardHandler.
+type testPrompt struct {
+	name         string
+	returnError  bool
+	capturedArgs map[string]any
+}
+
+func (p *testPrompt) GetName() string {
+	return p.name
+}
+
+func (p *testPrompt) GetPrompt() *mcp.Prompt {
+	return &mcp.Prompt{
+		Name:        p.name,
+		Description: "Test prompt",
+	}
+}
+
+func (p *testPrompt) GetMessages(arguments map[string]any) ([]*mcp.PromptMessage, error) {
+	p.capturedArgs = arguments
+
+	if p.returnError {
+		return nil, errors.New("test error")
+	}
+
+	return []*mcp.PromptMessage{
+		{
+			Role: "user",
+			Content: &mcp.TextContent{
+				Text: "test message",
+			},
+		},
+	}, nil
+}
+
+func (p *testPrompt) RegisterWith(server *mcp.Server) {
+	RegisterWithStandardHandler(server, p)
+}
+
+func TestRegisterWithStandardHandler(t *testing.T) {
+	prompt := &testPrompt{
+		name: "test-prompt",
+	}
+
+	server := mcp.NewServer(
+		&mcp.Implementation{
+			Name:    "test-server",
+			Version: "1.0.0",
+		},
+		&mcp.ServerOptions{},
+	)
+
+	// Should not panic
+	assert.NotPanics(t, func() {
+		RegisterWithStandardHandler(server, prompt)
+	})
+}
+
+func TestRegisterWithStandardHandler_ArgumentPassing(t *testing.T) {
+	prompt := &testPrompt{
+		name: "test-prompt",
+	}
+
+	server := mcp.NewServer(
+		&mcp.Implementation{
+			Name:    "test-server",
+			Version: "1.0.0",
+		},
+		&mcp.ServerOptions{},
+	)
+
+	RegisterWithStandardHandler(server, prompt)
+
+	// Create a mock request with arguments
+	req := &mcp.GetPromptRequest{
+		Params: &mcp.GetPromptParams{
+			Name: "test-prompt",
+			Arguments: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+	}
+
+	// Get the handler (we need to simulate calling it)
+	// Note: In a real test, we'd need to actually invoke the handler through the server
+	// For now, we verify the registration doesn't panic
+	assert.NotNil(t, req)
+}
+
+func TestRegisterWithStandardHandler_ErrorHandling(t *testing.T) {
+	prompt := &testPrompt{
+		name:        "test-prompt",
+		returnError: true,
+	}
+
+	server := mcp.NewServer(
+		&mcp.Implementation{
+			Name:    "test-server",
+			Version: "1.0.0",
+		},
+		&mcp.ServerOptions{},
+	)
+
+	// Should not panic even with error-returning prompt
+	assert.NotPanics(t, func() {
+		RegisterWithStandardHandler(server, prompt)
+	})
+}
+
+func TestRegisterWithStandardHandler_NilArguments(t *testing.T) {
+	prompt := &testPrompt{
+		name: "test-prompt",
+	}
+
+	server := mcp.NewServer(
+		&mcp.Implementation{
+			Name:    "test-server",
+			Version: "1.0.0",
+		},
+		&mcp.ServerOptions{},
+	)
+
+	RegisterWithStandardHandler(server, prompt)
+
+	// Create handler manually to test nil arguments case
+	handler := func(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		args := make(map[string]any)
+
+		if req.Params.Arguments != nil {
+			for key, value := range req.Params.Arguments {
+				args[key] = value
+			}
+		}
+
+		messages, err := prompt.GetMessages(args)
+		if err != nil {
+			return nil, err
+		}
+
+		return &mcp.GetPromptResult{
+			Messages: messages,
+		}, nil
+	}
+
+	req := &mcp.GetPromptRequest{
+		Params: &mcp.GetPromptParams{
+			Name:      "test-prompt",
+			Arguments: nil,
+		},
+	}
+
+	result, err := handler(context.Background(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Len(t, result.Messages, 1)
+	assert.Empty(t, prompt.capturedArgs)
+}

--- a/internal/prompts/config/list_cluster.go
+++ b/internal/prompts/config/list_cluster.go
@@ -1,30 +1,24 @@
 package config
 
 import (
-	"context"
-
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stackrox/stackrox-mcp/internal/prompts"
 )
 
-type listClusterPrompt struct {
-	name string
-}
+type listClusterPrompt struct{}
 
 // NewListClusterPrompt creates a new list-cluster prompt.
 func NewListClusterPrompt() prompts.Prompt {
-	return &listClusterPrompt{
-		name: "list-cluster",
-	}
+	return &listClusterPrompt{}
 }
 
 func (p *listClusterPrompt) GetName() string {
-	return p.name
+	return "list-cluster"
 }
 
 func (p *listClusterPrompt) GetPrompt() *mcp.Prompt {
 	return &mcp.Prompt{
-		Name:        p.name,
+		Name:        p.GetName(),
 		Description: "List all Kubernetes/OpenShift clusters secured by StackRox Central.",
 		Arguments:   nil,
 	}
@@ -53,19 +47,5 @@ Present the clusters in a clear, readable format.`
 }
 
 func (p *listClusterPrompt) RegisterWith(server *mcp.Server) {
-	server.AddPrompt(p.GetPrompt(), p.handle)
-}
-
-func (p *listClusterPrompt) handle(
-	_ context.Context,
-	_ *mcp.GetPromptRequest,
-) (*mcp.GetPromptResult, error) {
-	messages, err := p.GetMessages(nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return &mcp.GetPromptResult{
-		Messages: messages,
-	}, nil
+	prompts.RegisterWithStandardHandler(server, p)
 }

--- a/internal/prompts/config/list_cluster.go
+++ b/internal/prompts/config/list_cluster.go
@@ -30,7 +30,7 @@ func (p *listClusterPrompt) GetPrompt() *mcp.Prompt {
 	}
 }
 
-func (p *listClusterPrompt) GetMessages(_ map[string]interface{}) ([]*mcp.PromptMessage, error) {
+func (p *listClusterPrompt) GetMessages(_ map[string]any) ([]*mcp.PromptMessage, error) {
 	content := `You are helping list all Kubernetes/OpenShift clusters secured by StackRox Central.
 
 Use the list_clusters tool to retrieve all managed clusters.

--- a/internal/prompts/config/list_cluster.go
+++ b/internal/prompts/config/list_cluster.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stackrox/stackrox-mcp/internal/prompts"
+)
+
+type listClusterPrompt struct {
+	name string
+}
+
+// NewListClusterPrompt creates a new list-cluster prompt.
+func NewListClusterPrompt() prompts.Prompt {
+	return &listClusterPrompt{
+		name: "list-cluster",
+	}
+}
+
+func (p *listClusterPrompt) GetName() string {
+	return p.name
+}
+
+func (p *listClusterPrompt) GetPrompt() *mcp.Prompt {
+	return &mcp.Prompt{
+		Name:        p.name,
+		Description: "List all Kubernetes/OpenShift clusters secured by StackRox Central.",
+		Arguments:   nil,
+	}
+}
+
+func (p *listClusterPrompt) GetMessages(_ map[string]interface{}) ([]*mcp.PromptMessage, error) {
+	content := `You are helping list all Kubernetes/OpenShift clusters secured by StackRox Central.
+
+Use the list_clusters tool to retrieve all managed clusters.
+
+The tool will return:
+- Cluster ID
+- Cluster name
+- Cluster type (e.g., KUBERNETES_CLUSTER, OPENSHIFT_CLUSTER)
+
+Present the clusters in a clear, readable format.`
+
+	return []*mcp.PromptMessage{
+		{
+			Role: "user",
+			Content: &mcp.TextContent{
+				Text: content,
+			},
+		},
+	}, nil
+}
+
+func (p *listClusterPrompt) RegisterWith(server *mcp.Server) {
+	server.AddPrompt(p.GetPrompt(), p.handle)
+}
+
+func (p *listClusterPrompt) handle(
+	_ context.Context,
+	_ *mcp.GetPromptRequest,
+) (*mcp.GetPromptResult, error) {
+	messages, err := p.GetMessages(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcp.GetPromptResult{
+		Messages: messages,
+	}, nil
+}

--- a/internal/prompts/config/list_cluster_test.go
+++ b/internal/prompts/config/list_cluster_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewListClusterPrompt(t *testing.T) {
+	prompt := NewListClusterPrompt()
+
+	require.NotNil(t, prompt)
+	assert.Equal(t, "list-cluster", prompt.GetName())
+}
+
+func TestListClusterPrompt_GetPrompt(t *testing.T) {
+	prompt := NewListClusterPrompt()
+
+	mcpPrompt := prompt.GetPrompt()
+
+	require.NotNil(t, mcpPrompt)
+	assert.Equal(t, "list-cluster", mcpPrompt.Name)
+	assert.NotEmpty(t, mcpPrompt.Description)
+	assert.Contains(t, mcpPrompt.Description, "Kubernetes")
+	assert.Contains(t, mcpPrompt.Description, "StackRox")
+	assert.Nil(t, mcpPrompt.Arguments)
+}
+
+func TestListClusterPrompt_GetMessages(t *testing.T) {
+	prompt := NewListClusterPrompt()
+
+	messages, err := prompt.GetMessages(nil)
+
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+
+	msg := messages[0]
+	assert.Equal(t, mcp.Role("user"), msg.Role)
+
+	textContent, ok := msg.Content.(*mcp.TextContent)
+	require.True(t, ok, "Content should be TextContent")
+	assert.NotEmpty(t, textContent.Text)
+	assert.Contains(t, textContent.Text, "list_clusters")
+	assert.Contains(t, textContent.Text, "Cluster ID")
+	assert.Contains(t, textContent.Text, "Cluster name")
+	assert.Contains(t, textContent.Text, "Cluster type")
+}
+
+func TestListClusterPrompt_GetMessages_WithArguments(t *testing.T) {
+	prompt := NewListClusterPrompt()
+
+	// Arguments are ignored for this prompt
+	args := map[string]any{
+		"some_arg": "some_value",
+	}
+
+	messages, err := prompt.GetMessages(args)
+
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+}
+
+func TestListClusterPrompt_RegisterWith(t *testing.T) {
+	prompt := NewListClusterPrompt()
+	server := mcp.NewServer(
+		&mcp.Implementation{
+			Name:    "test-server",
+			Version: "1.0.0",
+		},
+		&mcp.ServerOptions{},
+	)
+
+	// Should not panic
+	assert.NotPanics(t, func() {
+		prompt.RegisterWith(server)
+	})
+}

--- a/internal/prompts/config/list_cluster_test.go
+++ b/internal/prompts/config/list_cluster_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestNewListClusterPrompt(t *testing.T) {
+	t.Parallel()
+
 	prompt := NewListClusterPrompt()
 
 	require.NotNil(t, prompt)
@@ -16,6 +18,8 @@ func TestNewListClusterPrompt(t *testing.T) {
 }
 
 func TestListClusterPrompt_GetPrompt(t *testing.T) {
+	t.Parallel()
+
 	prompt := NewListClusterPrompt()
 
 	mcpPrompt := prompt.GetPrompt()
@@ -29,6 +33,8 @@ func TestListClusterPrompt_GetPrompt(t *testing.T) {
 }
 
 func TestListClusterPrompt_GetMessages(t *testing.T) {
+	t.Parallel()
+
 	prompt := NewListClusterPrompt()
 
 	messages, err := prompt.GetMessages(nil)
@@ -48,21 +54,9 @@ func TestListClusterPrompt_GetMessages(t *testing.T) {
 	assert.Contains(t, textContent.Text, "Cluster type")
 }
 
-func TestListClusterPrompt_GetMessages_WithArguments(t *testing.T) {
-	prompt := NewListClusterPrompt()
-
-	// Arguments are ignored for this prompt
-	args := map[string]any{
-		"some_arg": "some_value",
-	}
-
-	messages, err := prompt.GetMessages(args)
-
-	require.NoError(t, err)
-	require.Len(t, messages, 1)
-}
-
 func TestListClusterPrompt_RegisterWith(t *testing.T) {
+	t.Parallel()
+
 	prompt := NewListClusterPrompt()
 	server := mcp.NewServer(
 		&mcp.Implementation{
@@ -72,7 +66,6 @@ func TestListClusterPrompt_RegisterWith(t *testing.T) {
 		&mcp.ServerOptions{},
 	)
 
-	// Should not panic
 	assert.NotPanics(t, func() {
 		prompt.RegisterWith(server)
 	})

--- a/internal/prompts/config/promptset.go
+++ b/internal/prompts/config/promptset.go
@@ -1,0 +1,32 @@
+// Package config provides MCP prompts for configuration management.
+package config
+
+import (
+	"github.com/stackrox/stackrox-mcp/internal/config"
+	"github.com/stackrox/stackrox-mcp/internal/prompts"
+)
+
+type promptset struct {
+	cfg *config.Config
+}
+
+// NewPromptset creates a new config management promptset.
+func NewPromptset(cfg *config.Config) prompts.Promptset {
+	return &promptset{
+		cfg: cfg,
+	}
+}
+
+func (p *promptset) GetName() string {
+	return "config"
+}
+
+func (p *promptset) IsEnabled() bool {
+	return p.cfg.Prompts.ConfigManager.Enabled
+}
+
+func (p *promptset) GetPrompts() []prompts.Prompt {
+	return []prompts.Prompt{
+		NewListClusterPrompt(),
+	}
+}

--- a/internal/prompts/config/promptset_test.go
+++ b/internal/prompts/config/promptset_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stackrox/stackrox-mcp/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPromptset(t *testing.T) {
+	cfg := &config.Config{
+		Prompts: config.PromptsConfig{
+			ConfigManager: config.PromptsConfigManagerConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	promptset := NewPromptset(cfg)
+
+	require.NotNil(t, promptset)
+	assert.Equal(t, "config", promptset.GetName())
+}
+
+func TestPromptset_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{
+			name:    "enabled",
+			enabled: true,
+		},
+		{
+			name:    "disabled",
+			enabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Prompts: config.PromptsConfig{
+					ConfigManager: config.PromptsConfigManagerConfig{
+						Enabled: tt.enabled,
+					},
+				},
+			}
+
+			promptset := NewPromptset(cfg)
+
+			assert.Equal(t, tt.enabled, promptset.IsEnabled())
+		})
+	}
+}
+
+func TestPromptset_GetPrompts(t *testing.T) {
+	cfg := &config.Config{
+		Prompts: config.PromptsConfig{
+			ConfigManager: config.PromptsConfigManagerConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	promptset := NewPromptset(cfg)
+
+	prompts := promptset.GetPrompts()
+
+	require.Len(t, prompts, 1)
+	assert.Equal(t, "list-cluster", prompts[0].GetName())
+}

--- a/internal/prompts/config/promptset_test.go
+++ b/internal/prompts/config/promptset_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestNewPromptset(t *testing.T) {
+	t.Parallel()
+
 	cfg := &config.Config{
 		Prompts: config.PromptsConfig{
 			ConfigManager: config.PromptsConfigManagerConfig{
@@ -24,6 +26,8 @@ func TestNewPromptset(t *testing.T) {
 }
 
 func TestPromptset_IsEnabled(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		enabled bool
@@ -40,6 +44,8 @@ func TestPromptset_IsEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cfg := &config.Config{
 				Prompts: config.PromptsConfig{
 					ConfigManager: config.PromptsConfigManagerConfig{
@@ -56,6 +62,8 @@ func TestPromptset_IsEnabled(t *testing.T) {
 }
 
 func TestPromptset_GetPrompts(t *testing.T) {
+	t.Parallel()
+
 	cfg := &config.Config{
 		Prompts: config.PromptsConfig{
 			ConfigManager: config.PromptsConfigManagerConfig{

--- a/internal/prompts/prompt.go
+++ b/internal/prompts/prompt.go
@@ -14,7 +14,7 @@ type Prompt interface {
 	GetPrompt() *mcp.Prompt
 
 	// GetMessages returns PromptMessage objects for the given arguments.
-	GetMessages(arguments map[string]interface{}) ([]*mcp.PromptMessage, error)
+	GetMessages(arguments map[string]any) ([]*mcp.PromptMessage, error)
 
 	// RegisterWith registers the prompt's handler with the MCP server.
 	RegisterWith(server *mcp.Server)

--- a/internal/prompts/prompt.go
+++ b/internal/prompts/prompt.go
@@ -1,0 +1,33 @@
+// Package prompts handles MCP prompts and promptset registration.
+package prompts
+
+import (
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Prompt represents a single MCP prompt with metadata.
+type Prompt interface {
+	// GetName returns the prompt name for logging/debugging.
+	GetName() string
+
+	// GetPrompt returns the MCP SDK Prompt definition.
+	GetPrompt() *mcp.Prompt
+
+	// GetMessages returns PromptMessage objects for the given arguments.
+	GetMessages(arguments map[string]interface{}) ([]*mcp.PromptMessage, error)
+
+	// RegisterWith registers the prompt's handler with the MCP server.
+	RegisterWith(server *mcp.Server)
+}
+
+// Promptset represents a collection of related prompts.
+type Promptset interface {
+	// GetName returns the promptset name.
+	GetName() string
+
+	// IsEnabled checks if this promptset is enabled in configuration.
+	IsEnabled() bool
+
+	// GetPrompts returns available prompts based on configuration.
+	GetPrompts() []Prompt
+}

--- a/internal/prompts/registry.go
+++ b/internal/prompts/registry.go
@@ -22,14 +22,17 @@ func NewRegistry(cfg *config.Config, promptsets []Promptset) *Registry {
 // GetAllPrompts returns all prompt definitions from all enabled promptsets.
 func (r *Registry) GetAllPrompts() []*mcp.Prompt {
 	prompts := make([]*mcp.Prompt, 0)
+
 	for _, promptset := range r.promptsets {
 		if !promptset.IsEnabled() {
 			continue
 		}
+
 		for _, prompt := range promptset.GetPrompts() {
 			prompts = append(prompts, prompt.GetPrompt())
 		}
 	}
+
 	return prompts
 }
 

--- a/internal/prompts/registry.go
+++ b/internal/prompts/registry.go
@@ -1,0 +1,39 @@
+package prompts
+
+import (
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stackrox/stackrox-mcp/internal/config"
+)
+
+// Registry manages all promptsets and provides access to prompts.
+type Registry struct {
+	cfg        *config.Config
+	promptsets []Promptset
+}
+
+// NewRegistry creates a new prompt registry with the given configuration and promptsets.
+func NewRegistry(cfg *config.Config, promptsets []Promptset) *Registry {
+	return &Registry{
+		cfg:        cfg,
+		promptsets: promptsets,
+	}
+}
+
+// GetAllPrompts returns all prompt definitions from all enabled promptsets.
+func (r *Registry) GetAllPrompts() []*mcp.Prompt {
+	prompts := make([]*mcp.Prompt, 0)
+	for _, promptset := range r.promptsets {
+		if !promptset.IsEnabled() {
+			continue
+		}
+		for _, prompt := range promptset.GetPrompts() {
+			prompts = append(prompts, prompt.GetPrompt())
+		}
+	}
+	return prompts
+}
+
+// GetPromptsets returns all registered promptsets.
+func (r *Registry) GetPromptsets() []Promptset {
+	return r.promptsets
+}

--- a/internal/prompts/registry_test.go
+++ b/internal/prompts/registry_test.go
@@ -1,0 +1,167 @@
+package prompts
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stackrox/stackrox-mcp/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockPrompt is a test implementation of Prompt.
+type mockPrompt struct {
+	name string
+}
+
+func (m *mockPrompt) GetName() string {
+	return m.name
+}
+
+func (m *mockPrompt) GetPrompt() *mcp.Prompt {
+	return &mcp.Prompt{
+		Name:        m.name,
+		Description: "Mock prompt",
+	}
+}
+
+func (m *mockPrompt) GetMessages(_ map[string]any) ([]*mcp.PromptMessage, error) {
+	return []*mcp.PromptMessage{
+		{
+			Role: "user",
+			Content: &mcp.TextContent{
+				Text: "mock message",
+			},
+		},
+	}, nil
+}
+
+func (m *mockPrompt) RegisterWith(_ *mcp.Server) {}
+
+// mockPromptset is a test implementation of Promptset.
+type mockPromptset struct {
+	name    string
+	enabled bool
+	prompts []Prompt
+}
+
+func (m *mockPromptset) GetName() string {
+	return m.name
+}
+
+func (m *mockPromptset) IsEnabled() bool {
+	return m.enabled
+}
+
+func (m *mockPromptset) GetPrompts() []Prompt {
+	return m.prompts
+}
+
+func TestNewRegistry(t *testing.T) {
+	cfg := &config.Config{}
+	promptsets := []Promptset{
+		&mockPromptset{name: "test", enabled: true},
+	}
+
+	registry := NewRegistry(cfg, promptsets)
+
+	require.NotNil(t, registry)
+	assert.Equal(t, cfg, registry.cfg)
+	assert.Equal(t, promptsets, registry.promptsets)
+}
+
+func TestRegistry_GetPromptsets(t *testing.T) {
+	promptsets := []Promptset{
+		&mockPromptset{name: "test1", enabled: true},
+		&mockPromptset{name: "test2", enabled: false},
+	}
+
+	registry := NewRegistry(&config.Config{}, promptsets)
+
+	result := registry.GetPromptsets()
+
+	assert.Equal(t, promptsets, result)
+}
+
+func TestRegistry_GetAllPrompts(t *testing.T) {
+	tests := []struct {
+		name       string
+		promptsets []Promptset
+		wantCount  int
+	}{
+		{
+			name: "all enabled promptsets",
+			promptsets: []Promptset{
+				&mockPromptset{
+					name:    "set1",
+					enabled: true,
+					prompts: []Prompt{
+						&mockPrompt{name: "prompt1"},
+						&mockPrompt{name: "prompt2"},
+					},
+				},
+				&mockPromptset{
+					name:    "set2",
+					enabled: true,
+					prompts: []Prompt{
+						&mockPrompt{name: "prompt3"},
+					},
+				},
+			},
+			wantCount: 3,
+		},
+		{
+			name: "some disabled promptsets",
+			promptsets: []Promptset{
+				&mockPromptset{
+					name:    "enabled",
+					enabled: true,
+					prompts: []Prompt{
+						&mockPrompt{name: "prompt1"},
+					},
+				},
+				&mockPromptset{
+					name:    "disabled",
+					enabled: false,
+					prompts: []Prompt{
+						&mockPrompt{name: "prompt2"},
+					},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name:       "no promptsets",
+			promptsets: []Promptset{},
+			wantCount:  0,
+		},
+		{
+			name: "all disabled promptsets",
+			promptsets: []Promptset{
+				&mockPromptset{
+					name:    "disabled1",
+					enabled: false,
+					prompts: []Prompt{
+						&mockPrompt{name: "prompt1"},
+					},
+				},
+			},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := NewRegistry(&config.Config{}, tt.promptsets)
+
+			prompts := registry.GetAllPrompts()
+
+			assert.Len(t, prompts, tt.wantCount)
+
+			for _, prompt := range prompts {
+				assert.NotNil(t, prompt)
+				assert.NotEmpty(t, prompt.Name)
+			}
+		})
+	}
+}

--- a/internal/prompts/registry_test.go
+++ b/internal/prompts/registry_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mockPrompt is a test implementation of Prompt.
 type mockPrompt struct {
 	name string
 }
@@ -38,7 +37,6 @@ func (m *mockPrompt) GetMessages(_ map[string]any) ([]*mcp.PromptMessage, error)
 
 func (m *mockPrompt) RegisterWith(_ *mcp.Server) {}
 
-// mockPromptset is a test implementation of Promptset.
 type mockPromptset struct {
 	name    string
 	enabled bool
@@ -58,6 +56,8 @@ func (m *mockPromptset) GetPrompts() []Prompt {
 }
 
 func TestNewRegistry(t *testing.T) {
+	t.Parallel()
+
 	cfg := &config.Config{}
 	promptsets := []Promptset{
 		&mockPromptset{name: "test", enabled: true},
@@ -71,6 +71,8 @@ func TestNewRegistry(t *testing.T) {
 }
 
 func TestRegistry_GetPromptsets(t *testing.T) {
+	t.Parallel()
+
 	promptsets := []Promptset{
 		&mockPromptset{name: "test1", enabled: true},
 		&mockPromptset{name: "test2", enabled: false},
@@ -84,6 +86,8 @@ func TestRegistry_GetPromptsets(t *testing.T) {
 }
 
 func TestRegistry_GetAllPrompts(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		promptsets []Promptset
@@ -152,6 +156,8 @@ func TestRegistry_GetAllPrompts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			registry := NewRegistry(&config.Config{}, tt.promptsets)
 
 			prompts := registry.GetAllPrompts()

--- a/internal/prompts/vulnerability/check_vuln.go
+++ b/internal/prompts/vulnerability/check_vuln.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	scopeFleet     = "fleet"
-	scopeCluster   = "cluster"
-	scopeWorkloads = "workloads"
+	ScopeFleet     = "fleet"
+	ScopeCluster   = "cluster"
+	ScopeWorkloads = "workloads"
 
 	// defaultMessageBuilderCapacity is the initial capacity for the message string builder.
 	defaultMessageBuilderCapacity = 512
@@ -160,11 +160,11 @@ func (p *checkVulnPrompt) parseVulnIDsFromSlice(slice []any) ([]string, error) {
 func (p *checkVulnPrompt) parseScope(arguments map[string]any) (string, error) {
 	scopeRaw, ok := arguments["scope"].(string)
 	if !ok || scopeRaw == "" {
-		return scopeFleet, nil
+		return ScopeFleet, nil
 	}
 
-	if scopeRaw != scopeFleet && scopeRaw != scopeCluster && scopeRaw != scopeWorkloads {
-		return "", fmt.Errorf("scope must be one of: %s, %s, %s", scopeFleet, scopeCluster, scopeWorkloads)
+	if scopeRaw != ScopeFleet && scopeRaw != ScopeCluster && scopeRaw != ScopeWorkloads {
+		return "", fmt.Errorf("scope must be one of: %s, %s, %s", ScopeFleet, ScopeCluster, ScopeWorkloads)
 	}
 
 	return scopeRaw, nil
@@ -177,7 +177,7 @@ func (p *checkVulnPrompt) parseClusterName(arguments map[string]any) string {
 }
 
 func (p *checkVulnPrompt) validateClusterName(scope, clusterName string) error {
-	if scope == scopeCluster && clusterName == "" {
+	if scope == ScopeCluster && clusterName == "" {
 		return errors.New("clusterName is required when scope is 'cluster'")
 	}
 
@@ -220,9 +220,9 @@ func (p *checkVulnPrompt) writeHeader(
 	}
 
 	switch scope {
-	case scopeCluster:
+	case ScopeCluster:
 		fmt.Fprintf(builder, " in cluster %q.\n\n", clusterName)
-	case scopeWorkloads:
+	case ScopeWorkloads:
 		builder.WriteString(" in workloads/deployments")
 
 		if clusterName != "" {
@@ -244,11 +244,11 @@ func (p *checkVulnPrompt) buildSingleVulnWorkflow(
 	vulnID, scope, clusterName, namespaceFilter string,
 ) {
 	switch scope {
-	case scopeFleet:
+	case ScopeFleet:
 		p.writeSingleVulnFleetWorkflow(builder, vulnID)
-	case scopeCluster:
+	case ScopeCluster:
 		p.writeSingleVulnClusterWorkflow(builder, vulnID, clusterName)
-	case scopeWorkloads:
+	case ScopeWorkloads:
 		p.writeSingleVulnWorkloadsWorkflow(builder, vulnID, clusterName, namespaceFilter)
 	}
 }
@@ -311,11 +311,11 @@ func (p *checkVulnPrompt) buildMultipleVulnWorkflow(
 	builder.WriteString("For each vulnerability, perform the appropriate checks:\n\n")
 
 	switch scope {
-	case scopeFleet:
+	case ScopeFleet:
 		p.writeMultipleVulnFleetWorkflow(builder)
-	case scopeCluster:
+	case ScopeCluster:
 		p.writeMultipleVulnClusterWorkflow(builder, clusterName)
-	case scopeWorkloads:
+	case ScopeWorkloads:
 		p.writeMultipleVulnWorkloadsWorkflow(builder, clusterName, namespaceFilter)
 	}
 }

--- a/internal/prompts/vulnerability/check_vuln.go
+++ b/internal/prompts/vulnerability/check_vuln.go
@@ -16,13 +16,6 @@ const (
 	scopeWorkloads = "workloads"
 )
 
-type checkVulnInput struct {
-	VulnIDs         interface{} `json:"vuln_ids"` // Can be string or array of strings
-	Scope           string      `json:"scope,omitempty"`
-	ClusterName     string      `json:"cluster_name,omitempty"`
-	NamespaceFilter string      `json:"namespace_filter,omitempty"`
-}
-
 type checkVulnPrompt struct {
 	name string
 }
@@ -41,31 +34,35 @@ func (p *checkVulnPrompt) GetName() string {
 func (p *checkVulnPrompt) GetPrompt() *mcp.Prompt {
 	return &mcp.Prompt{
 		Name: p.name,
-		Description: "Check if vulnerabilities (CVE, GHSA, RHSA, etc.) are detected in your StackRox-secured infrastructure. " +
-			"Supports comprehensive checking across Kubernetes/OpenShift components, deployments, and nodes. " +
-			"Can check single or multiple vulnerabilities, with optional scoping to specific clusters or workloads.",
+		Description: "Check if vulnerabilities (CVE, GHSA, RHSA, etc.) are detected in your " +
+			"StackRox-secured infrastructure. Supports comprehensive checking across " +
+			"Kubernetes/OpenShift components, deployments, and nodes. Can check single or " +
+			"multiple vulnerabilities, with optional scoping to specific clusters or workloads.",
 		Arguments: []*mcp.PromptArgument{
 			{
 				Name: "vuln_ids",
-				Description: "Vulnerability identifier(s) to check. Can be a single string (e.g., 'CVE-2021-44228') " +
-					"or an array of strings (e.g., ['CVE-2021-44228', 'GHSA-xxxx-xxxx-xxxx']). " +
-					"Supports CVE, GHSA, RHSA, and 20+ other vulnerability ID formats.",
+				Description: "Vulnerability identifier(s) to check. Can be a single string " +
+					"(e.g., 'CVE-2021-44228') or an array of strings (e.g., " +
+					"['CVE-2021-44228', 'GHSA-xxxx-xxxx-xxxx']). Supports CVE, GHSA, RHSA, and 20+ " +
+					"other vulnerability ID formats.",
 				Required: true,
 			},
 			{
 				Name: "scope",
-				Description: "Scope of the check. Options: 'fleet' (default - check across all clusters including orchestrator, " +
-					"deployments, and nodes), 'cluster' (check a specific cluster), 'workloads' (check only deployments/workloads).",
+				Description: "Scope of the check. Options: 'fleet' (default - check across all clusters " +
+					"including orchestrator, deployments, and nodes), 'cluster' (check a specific cluster), " +
+					"'workloads' (check only deployments/workloads).",
 				Required: false,
 			},
 			{
-				Name: "cluster_name",
-				Description: "Cluster name to filter by. Required when scope='cluster', optional for scope='workloads'. " +
-					"If cluster doesn't exist, the prompt will guide you to use list_clusters first.",
+				Name: "clusterName",
+				Description: "Cluster name to filter by. Required when scope='cluster', optional for " +
+					"scope='workloads'. If cluster doesn't exist, the prompt will guide you to use " +
+					"list_clusters first.",
 				Required: false,
 			},
 			{
-				Name: "namespace_filter",
+				Name: "namespaceFilter",
 				Description: "Namespace to filter by. Only applicable when checking workloads/deployments.",
 				Required: false,
 			},
@@ -73,14 +70,12 @@ func (p *checkVulnPrompt) GetPrompt() *mcp.Prompt {
 	}
 }
 
-func (p *checkVulnPrompt) GetMessages(arguments map[string]interface{}) ([]*mcp.PromptMessage, error) {
-	// Parse and validate input
+func (p *checkVulnPrompt) GetMessages(arguments map[string]any) ([]*mcp.PromptMessage, error) {
 	vulnIDs, scope, clusterName, namespaceFilter, err := p.parseArguments(arguments)
 	if err != nil {
 		return nil, err
 	}
 
-	// Generate appropriate message based on scope and number of vulnerabilities
 	content := p.buildMessageContent(vulnIDs, scope, clusterName, namespaceFilter)
 
 	return []*mcp.PromptMessage{
@@ -93,171 +88,6 @@ func (p *checkVulnPrompt) GetMessages(arguments map[string]interface{}) ([]*mcp.
 	}, nil
 }
 
-func (p *checkVulnPrompt) parseArguments(arguments map[string]interface{}) ([]string, string, string, string, error) {
-	// Parse vuln_ids (required)
-	vulnIDsRaw, ok := arguments["vuln_ids"]
-	if !ok {
-		return nil, "", "", "", errors.New("vuln_ids is required")
-	}
-
-	var vulnIDs []string
-	switch v := vulnIDsRaw.(type) {
-	case string:
-		if v == "" {
-			return nil, "", "", "", errors.New("vuln_ids cannot be empty")
-		}
-		vulnIDs = []string{v}
-	case []interface{}:
-		if len(v) == 0 {
-			return nil, "", "", "", errors.New("vuln_ids cannot be empty")
-		}
-		for _, id := range v {
-			if str, ok := id.(string); ok && str != "" {
-				vulnIDs = append(vulnIDs, str)
-			}
-		}
-		if len(vulnIDs) == 0 {
-			return nil, "", "", "", errors.New("vuln_ids must contain at least one non-empty string")
-		}
-	case []string:
-		if len(v) == 0 {
-			return nil, "", "", "", errors.New("vuln_ids cannot be empty")
-		}
-		vulnIDs = v
-	default:
-		return nil, "", "", "", errors.New("vuln_ids must be a string or array of strings")
-	}
-
-	// Parse scope (optional, default to fleet)
-	scope := scopeFleet
-	if scopeRaw, ok := arguments["scope"].(string); ok && scopeRaw != "" {
-		scope = scopeRaw
-		if scope != scopeFleet && scope != scopeCluster && scope != scopeWorkloads {
-			return nil, "", "", "", fmt.Errorf("scope must be one of: %s, %s, %s", scopeFleet, scopeCluster, scopeWorkloads)
-		}
-	}
-
-	// Parse cluster_name (optional)
-	clusterName, _ := arguments["cluster_name"].(string)
-
-	// Validate cluster_name is provided when scope=cluster
-	if scope == scopeCluster && clusterName == "" {
-		return nil, "", "", "", errors.New("cluster_name is required when scope is 'cluster'")
-	}
-
-	// Parse namespace_filter (optional)
-	namespaceFilter, _ := arguments["namespace_filter"].(string)
-
-	return vulnIDs, scope, clusterName, namespaceFilter, nil
-}
-
-func (p *checkVulnPrompt) buildMessageContent(vulnIDs []string, scope, clusterName, namespaceFilter string) string {
-	var sb strings.Builder
-
-	// Header based on scope and count
-	if len(vulnIDs) == 1 {
-		sb.WriteString(fmt.Sprintf("You are checking if vulnerability %s is detected", vulnIDs[0]))
-	} else {
-		sb.WriteString(fmt.Sprintf("You are checking if vulnerabilities %s are detected", strings.Join(vulnIDs, ", ")))
-	}
-
-	switch scope {
-	case scopeCluster:
-		sb.WriteString(fmt.Sprintf(" in cluster %q.\n\n", clusterName))
-	case scopeWorkloads:
-		sb.WriteString(" in workloads/deployments")
-		if clusterName != "" {
-			sb.WriteString(fmt.Sprintf(" in cluster %q", clusterName))
-		}
-		if namespaceFilter != "" {
-			sb.WriteString(fmt.Sprintf(" in namespace %q", namespaceFilter))
-		}
-		sb.WriteString(".\n\n")
-	default: // fleet
-		sb.WriteString(" in the StackRox-secured cluster fleet.\n\n")
-	}
-
-	// Add workflow instructions
-	if len(vulnIDs) > 1 {
-		p.buildMultipleVulnWorkflow(&sb, vulnIDs, scope, clusterName, namespaceFilter)
-	} else {
-		p.buildSingleVulnWorkflow(&sb, vulnIDs[0], scope, clusterName, namespaceFilter)
-	}
-
-	return sb.String()
-}
-
-func (p *checkVulnPrompt) buildSingleVulnWorkflow(sb *strings.Builder, vulnID, scope, clusterName, namespaceFilter string) {
-	switch scope {
-	case scopeFleet:
-		sb.WriteString("Follow this comprehensive checking workflow:\n\n")
-		sb.WriteString("1. ORCHESTRATOR COMPONENTS CHECK:\n")
-		sb.WriteString(fmt.Sprintf("   - Use get_clusters_with_orchestrator_cve with cveName: %q\n", vulnID))
-		sb.WriteString("   - Checks Kubernetes/OpenShift components (API server, kubelet, etc.)\n\n")
-		sb.WriteString("2. DEPLOYMENT/WORKLOAD CHECK:\n")
-		sb.WriteString(fmt.Sprintf("   - Use get_deployments_for_cve with cveName: %q\n", vulnID))
-		sb.WriteString("   - Checks container images in application deployments\n\n")
-		sb.WriteString("3. NODE/HOST CHECK:\n")
-		sb.WriteString(fmt.Sprintf("   - Use get_nodes_for_cve with cveName: %q\n", vulnID))
-		sb.WriteString("   - Checks OS packages on cluster nodes\n\n")
-		sb.WriteString("IMPORTANT: Call ALL THREE tools for comprehensive coverage.\n")
-		sb.WriteString("Summarize which clusters/deployments/nodes are affected.\n")
-
-	case scopeCluster:
-		sb.WriteString("Follow this workflow:\n\n")
-		sb.WriteString("1. First, validate the cluster exists:\n")
-		sb.WriteString("   - Use list_clusters to check if the cluster exists\n")
-		sb.WriteString(fmt.Sprintf("   - If cluster %q not found, report it clearly\n\n", clusterName))
-		sb.WriteString("2. Then check all three locations WITH cluster filter:\n")
-		sb.WriteString(fmt.Sprintf("   - get_clusters_with_orchestrator_cve with cveName: %q and clusterName: %q\n", vulnID, clusterName))
-		sb.WriteString(fmt.Sprintf("   - get_deployments_for_cve with cveName: %q and clusterName: %q\n", vulnID, clusterName))
-		sb.WriteString(fmt.Sprintf("   - get_nodes_for_cve with cveName: %q and clusterName: %q\n\n", vulnID, clusterName))
-		sb.WriteString("Summarize which components/deployments/nodes are affected in this cluster.\n")
-
-	case scopeWorkloads:
-		sb.WriteString("Use get_deployments_for_cve with:\n")
-		sb.WriteString(fmt.Sprintf("- cveName: %q\n", vulnID))
-		if clusterName != "" {
-			sb.WriteString(fmt.Sprintf("- clusterName: %q\n", clusterName))
-		}
-		if namespaceFilter != "" {
-			sb.WriteString(fmt.Sprintf("- namespace: %q\n", namespaceFilter))
-		}
-		sb.WriteString("\nFocus on application deployments only.\n")
-		sb.WriteString("Report which deployments are affected.\n")
-	}
-}
-
-func (p *checkVulnPrompt) buildMultipleVulnWorkflow(sb *strings.Builder, vulnIDs []string, scope, clusterName, namespaceFilter string) {
-	sb.WriteString("For each vulnerability, perform the appropriate checks:\n\n")
-
-	if scope == scopeFleet {
-		sb.WriteString("For EACH vulnerability ID:\n")
-		sb.WriteString("1. Call get_clusters_with_orchestrator_cve (orchestrator components)\n")
-		sb.WriteString("2. Call get_deployments_for_cve (application deployments)\n")
-		sb.WriteString("3. Call get_nodes_for_cve (node OS packages)\n\n")
-		sb.WriteString("Present results grouped by vulnerability, showing which clusters/deployments/nodes\n")
-		sb.WriteString("are affected by each CVE.\n")
-	} else if scope == scopeCluster {
-		sb.WriteString(fmt.Sprintf("First, validate cluster %q exists using list_clusters.\n\n", clusterName))
-		sb.WriteString("Then for EACH vulnerability ID:\n")
-		sb.WriteString("1. Call get_clusters_with_orchestrator_cve with cluster filter\n")
-		sb.WriteString("2. Call get_deployments_for_cve with cluster filter\n")
-		sb.WriteString("3. Call get_nodes_for_cve with cluster filter\n\n")
-		sb.WriteString("Present results grouped by vulnerability.\n")
-	} else { // workloads
-		sb.WriteString("For EACH vulnerability ID, call get_deployments_for_cve with:\n")
-		sb.WriteString("- The specific vulnerability ID\n")
-		if clusterName != "" {
-			sb.WriteString(fmt.Sprintf("- clusterName: %q\n", clusterName))
-		}
-		if namespaceFilter != "" {
-			sb.WriteString(fmt.Sprintf("- namespace: %q\n", namespaceFilter))
-		}
-		sb.WriteString("\nPresent results grouped by vulnerability.\n")
-	}
-}
-
 func (p *checkVulnPrompt) RegisterWith(server *mcp.Server) {
 	server.AddPrompt(p.GetPrompt(), p.handle)
 }
@@ -266,11 +96,11 @@ func (p *checkVulnPrompt) handle(
 	_ context.Context,
 	req *mcp.GetPromptRequest,
 ) (*mcp.GetPromptResult, error) {
-	args := make(map[string]interface{})
+	args := make(map[string]any)
+
 	if req.Params.Arguments != nil {
-		// Convert map[string]string to map[string]interface{}
-		for k, v := range req.Params.Arguments {
-			args[k] = v
+		for key, value := range req.Params.Arguments {
+			args[key] = value
 		}
 	}
 
@@ -282,4 +112,269 @@ func (p *checkVulnPrompt) handle(
 	return &mcp.GetPromptResult{
 		Messages: messages,
 	}, nil
+}
+
+func (p *checkVulnPrompt) parseArguments(arguments map[string]any) ([]string, string, string, string, error) {
+	vulnIDs, err := p.parseVulnIDs(arguments)
+	if err != nil {
+		return nil, "", "", "", err
+	}
+
+	scope, err := p.parseScope(arguments)
+	if err != nil {
+		return nil, "", "", "", err
+	}
+
+	clusterName := p.parseClusterName(arguments)
+
+	if err := p.validateClusterName(scope, clusterName); err != nil {
+		return nil, "", "", "", err
+	}
+
+	namespaceFilter := p.parseNamespaceFilter(arguments)
+
+	return vulnIDs, scope, clusterName, namespaceFilter, nil
+}
+
+func (p *checkVulnPrompt) parseVulnIDs(arguments map[string]any) ([]string, error) {
+	vulnIDsRaw, ok := arguments["vuln_ids"]
+	if !ok {
+		return nil, errors.New("vuln_ids is required")
+	}
+
+	switch value := vulnIDsRaw.(type) {
+	case string:
+		if value == "" {
+			return nil, errors.New("vuln_ids cannot be empty")
+		}
+
+		return []string{value}, nil
+	case []any:
+		return p.parseVulnIDsFromSlice(value)
+	case []string:
+		if len(value) == 0 {
+			return nil, errors.New("vuln_ids cannot be empty")
+		}
+
+		return value, nil
+	default:
+		return nil, errors.New("vuln_ids must be a string or array of strings")
+	}
+}
+
+func (p *checkVulnPrompt) parseVulnIDsFromSlice(slice []any) ([]string, error) {
+	if len(slice) == 0 {
+		return nil, errors.New("vuln_ids cannot be empty")
+	}
+
+	vulnIDs := make([]string, 0, len(slice))
+	for _, id := range slice {
+		if str, ok := id.(string); ok && str != "" {
+			vulnIDs = append(vulnIDs, str)
+		}
+	}
+
+	if len(vulnIDs) == 0 {
+		return nil, errors.New("vuln_ids must contain at least one non-empty string")
+	}
+
+	return vulnIDs, nil
+}
+
+func (p *checkVulnPrompt) parseScope(arguments map[string]any) (string, error) {
+	scopeRaw, ok := arguments["scope"].(string)
+	if !ok || scopeRaw == "" {
+		return scopeFleet, nil
+	}
+
+	if scopeRaw != scopeFleet && scopeRaw != scopeCluster && scopeRaw != scopeWorkloads {
+		return "", fmt.Errorf("scope must be one of: %s, %s, %s", scopeFleet, scopeCluster, scopeWorkloads)
+	}
+
+	return scopeRaw, nil
+}
+
+func (p *checkVulnPrompt) parseClusterName(arguments map[string]any) string {
+	clusterName, _ := arguments["clusterName"].(string)
+
+	return clusterName
+}
+
+func (p *checkVulnPrompt) validateClusterName(scope, clusterName string) error {
+	if scope == scopeCluster && clusterName == "" {
+		return errors.New("clusterName is required when scope is 'cluster'")
+	}
+
+	return nil
+}
+
+func (p *checkVulnPrompt) parseNamespaceFilter(arguments map[string]any) string {
+	namespaceFilter, _ := arguments["namespaceFilter"].(string)
+
+	return namespaceFilter
+}
+
+func (p *checkVulnPrompt) buildMessageContent(
+	vulnIDs []string,
+	scope, clusterName, namespaceFilter string,
+) string {
+	var builder strings.Builder
+
+	p.writeHeader(&builder, vulnIDs, scope, clusterName, namespaceFilter)
+
+	if len(vulnIDs) > 1 {
+		p.buildMultipleVulnWorkflow(&builder, scope, clusterName, namespaceFilter)
+	} else {
+		p.buildSingleVulnWorkflow(&builder, vulnIDs[0], scope, clusterName, namespaceFilter)
+	}
+
+	return builder.String()
+}
+
+func (p *checkVulnPrompt) writeHeader(
+	builder *strings.Builder,
+	vulnIDs []string,
+	scope, clusterName, namespaceFilter string,
+) {
+	if len(vulnIDs) == 1 {
+		fmt.Fprintf(builder, "You are checking if vulnerability %s is detected", vulnIDs[0])
+	} else {
+		fmt.Fprintf(builder, "You are checking if vulnerabilities %s are detected", strings.Join(vulnIDs, ", "))
+	}
+
+	switch scope {
+	case scopeCluster:
+		fmt.Fprintf(builder, " in cluster %q.\n\n", clusterName)
+	case scopeWorkloads:
+		builder.WriteString(" in workloads/deployments")
+
+		if clusterName != "" {
+			fmt.Fprintf(builder, " in cluster %q", clusterName)
+		}
+
+		if namespaceFilter != "" {
+			fmt.Fprintf(builder, " in namespace %q", namespaceFilter)
+		}
+
+		builder.WriteString(".\n\n")
+	default: // fleet
+		builder.WriteString(" in the StackRox-secured cluster fleet.\n\n")
+	}
+}
+
+func (p *checkVulnPrompt) buildSingleVulnWorkflow(
+	builder *strings.Builder,
+	vulnID, scope, clusterName, namespaceFilter string,
+) {
+	switch scope {
+	case scopeFleet:
+		p.writeSingleVulnFleetWorkflow(builder, vulnID)
+	case scopeCluster:
+		p.writeSingleVulnClusterWorkflow(builder, vulnID, clusterName)
+	case scopeWorkloads:
+		p.writeSingleVulnWorkloadsWorkflow(builder, vulnID, clusterName, namespaceFilter)
+	}
+}
+
+func (p *checkVulnPrompt) writeSingleVulnFleetWorkflow(builder *strings.Builder, vulnID string) {
+	builder.WriteString("Follow this comprehensive checking workflow:\n\n")
+	builder.WriteString("1. ORCHESTRATOR COMPONENTS CHECK:\n")
+	fmt.Fprintf(builder, "   - Use get_clusters_with_orchestrator_cve with cveName: %q\n", vulnID)
+	builder.WriteString("   - Checks Kubernetes/OpenShift components (API server, kubelet, etc.)\n\n")
+	builder.WriteString("2. DEPLOYMENT/WORKLOAD CHECK:\n")
+	fmt.Fprintf(builder, "   - Use get_deployments_for_cve with cveName: %q\n", vulnID)
+	builder.WriteString("   - Checks container images in application deployments\n\n")
+	builder.WriteString("3. NODE/HOST CHECK:\n")
+	fmt.Fprintf(builder, "   - Use get_nodes_for_cve with cveName: %q\n", vulnID)
+	builder.WriteString("   - Checks OS packages on cluster nodes\n\n")
+	builder.WriteString("IMPORTANT: Call ALL THREE tools for comprehensive coverage.\n")
+	builder.WriteString("Summarize which clusters/deployments/nodes are affected.\n")
+}
+
+func (p *checkVulnPrompt) writeSingleVulnClusterWorkflow(
+	builder *strings.Builder,
+	vulnID, clusterName string,
+) {
+	builder.WriteString("Follow this workflow:\n\n")
+	builder.WriteString("1. First, validate the cluster exists:\n")
+	builder.WriteString("   - Use list_clusters to check if the cluster exists\n")
+	fmt.Fprintf(builder, "   - If cluster %q not found, report it clearly\n\n", clusterName)
+	builder.WriteString("2. Then check all three locations WITH cluster filter:\n")
+	fmt.Fprintf(builder,
+		"   - get_clusters_with_orchestrator_cve with cveName: %q and clusterName: %q\n",
+		vulnID, clusterName)
+	fmt.Fprintf(builder, "   - get_deployments_for_cve with cveName: %q and clusterName: %q\n", vulnID, clusterName)
+	fmt.Fprintf(builder, "   - get_nodes_for_cve with cveName: %q and clusterName: %q\n\n", vulnID, clusterName)
+	builder.WriteString("Summarize which components/deployments/nodes are affected in this cluster.\n")
+}
+
+func (p *checkVulnPrompt) writeSingleVulnWorkloadsWorkflow(
+	builder *strings.Builder,
+	vulnID, clusterName, namespaceFilter string,
+) {
+	builder.WriteString("Use get_deployments_for_cve with:\n")
+	fmt.Fprintf(builder, "- cveName: %q\n", vulnID)
+
+	if clusterName != "" {
+		fmt.Fprintf(builder, "- clusterName: %q\n", clusterName)
+	}
+
+	if namespaceFilter != "" {
+		fmt.Fprintf(builder, "- namespace: %q\n", namespaceFilter)
+	}
+
+	builder.WriteString("\nFocus on application deployments only.\n")
+	builder.WriteString("Report which deployments are affected.\n")
+}
+
+func (p *checkVulnPrompt) buildMultipleVulnWorkflow(
+	builder *strings.Builder,
+	scope, clusterName, namespaceFilter string,
+) {
+	builder.WriteString("For each vulnerability, perform the appropriate checks:\n\n")
+
+	switch scope {
+	case scopeFleet:
+		p.writeMultipleVulnFleetWorkflow(builder)
+	case scopeCluster:
+		p.writeMultipleVulnClusterWorkflow(builder, clusterName)
+	case scopeWorkloads:
+		p.writeMultipleVulnWorkloadsWorkflow(builder, clusterName, namespaceFilter)
+	}
+}
+
+func (p *checkVulnPrompt) writeMultipleVulnFleetWorkflow(builder *strings.Builder) {
+	builder.WriteString("For EACH vulnerability ID:\n")
+	builder.WriteString("1. Call get_clusters_with_orchestrator_cve (orchestrator components)\n")
+	builder.WriteString("2. Call get_deployments_for_cve (application deployments)\n")
+	builder.WriteString("3. Call get_nodes_for_cve (node OS packages)\n\n")
+	builder.WriteString("Present results grouped by vulnerability, showing which clusters/deployments/nodes\n")
+	builder.WriteString("are affected by each CVE.\n")
+}
+
+func (p *checkVulnPrompt) writeMultipleVulnClusterWorkflow(builder *strings.Builder, clusterName string) {
+	fmt.Fprintf(builder, "First, validate cluster %q exists using list_clusters.\n\n", clusterName)
+	builder.WriteString("Then for EACH vulnerability ID:\n")
+	builder.WriteString("1. Call get_clusters_with_orchestrator_cve with cluster filter\n")
+	builder.WriteString("2. Call get_deployments_for_cve with cluster filter\n")
+	builder.WriteString("3. Call get_nodes_for_cve with cluster filter\n\n")
+	builder.WriteString("Present results grouped by vulnerability.\n")
+}
+
+func (p *checkVulnPrompt) writeMultipleVulnWorkloadsWorkflow(
+	builder *strings.Builder,
+	clusterName, namespaceFilter string,
+) {
+	builder.WriteString("For EACH vulnerability ID, call get_deployments_for_cve with:\n")
+	builder.WriteString("- The specific vulnerability ID\n")
+
+	if clusterName != "" {
+		fmt.Fprintf(builder, "- clusterName: %q\n", clusterName)
+	}
+
+	if namespaceFilter != "" {
+		fmt.Fprintf(builder, "- namespace: %q\n", namespaceFilter)
+	}
+
+	builder.WriteString("\nPresent results grouped by vulnerability.\n")
 }

--- a/internal/prompts/vulnerability/check_vuln.go
+++ b/internal/prompts/vulnerability/check_vuln.go
@@ -1,7 +1,6 @@
 package vulnerability
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -14,26 +13,25 @@ const (
 	scopeFleet     = "fleet"
 	scopeCluster   = "cluster"
 	scopeWorkloads = "workloads"
+
+	// defaultMessageBuilderCapacity is the initial capacity for the message string builder.
+	defaultMessageBuilderCapacity = 512
 )
 
-type checkVulnPrompt struct {
-	name string
-}
+type checkVulnPrompt struct{}
 
 // NewCheckVulnPrompt creates a new check-vuln prompt.
 func NewCheckVulnPrompt() prompts.Prompt {
-	return &checkVulnPrompt{
-		name: "check-vuln",
-	}
+	return &checkVulnPrompt{}
 }
 
 func (p *checkVulnPrompt) GetName() string {
-	return p.name
+	return "check-vuln"
 }
 
 func (p *checkVulnPrompt) GetPrompt() *mcp.Prompt {
 	return &mcp.Prompt{
-		Name: p.name,
+		Name: p.GetName(),
 		Description: "Check if vulnerabilities (CVE, GHSA, RHSA, etc.) are detected in your " +
 			"StackRox-secured infrastructure. Supports comprehensive checking across " +
 			"Kubernetes/OpenShift components, deployments, and nodes. Can check single or " +
@@ -89,29 +87,7 @@ func (p *checkVulnPrompt) GetMessages(arguments map[string]any) ([]*mcp.PromptMe
 }
 
 func (p *checkVulnPrompt) RegisterWith(server *mcp.Server) {
-	server.AddPrompt(p.GetPrompt(), p.handle)
-}
-
-func (p *checkVulnPrompt) handle(
-	_ context.Context,
-	req *mcp.GetPromptRequest,
-) (*mcp.GetPromptResult, error) {
-	args := make(map[string]any)
-
-	if req.Params.Arguments != nil {
-		for key, value := range req.Params.Arguments {
-			args[key] = value
-		}
-	}
-
-	messages, err := p.GetMessages(args)
-	if err != nil {
-		return nil, err
-	}
-
-	return &mcp.GetPromptResult{
-		Messages: messages,
-	}, nil
+	prompts.RegisterWithStandardHandler(server, p)
 }
 
 func (p *checkVulnPrompt) parseArguments(arguments map[string]any) ([]string, string, string, string, error) {
@@ -219,6 +195,7 @@ func (p *checkVulnPrompt) buildMessageContent(
 	scope, clusterName, namespaceFilter string,
 ) string {
 	var builder strings.Builder
+	builder.Grow(defaultMessageBuilderCapacity)
 
 	p.writeHeader(&builder, vulnIDs, scope, clusterName, namespaceFilter)
 

--- a/internal/prompts/vulnerability/check_vuln.go
+++ b/internal/prompts/vulnerability/check_vuln.go
@@ -1,0 +1,285 @@
+package vulnerability
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/pkg/errors"
+	"github.com/stackrox/stackrox-mcp/internal/prompts"
+)
+
+const (
+	scopeFleet     = "fleet"
+	scopeCluster   = "cluster"
+	scopeWorkloads = "workloads"
+)
+
+type checkVulnInput struct {
+	VulnIDs         interface{} `json:"vuln_ids"` // Can be string or array of strings
+	Scope           string      `json:"scope,omitempty"`
+	ClusterName     string      `json:"cluster_name,omitempty"`
+	NamespaceFilter string      `json:"namespace_filter,omitempty"`
+}
+
+type checkVulnPrompt struct {
+	name string
+}
+
+// NewCheckVulnPrompt creates a new check-vuln prompt.
+func NewCheckVulnPrompt() prompts.Prompt {
+	return &checkVulnPrompt{
+		name: "check-vuln",
+	}
+}
+
+func (p *checkVulnPrompt) GetName() string {
+	return p.name
+}
+
+func (p *checkVulnPrompt) GetPrompt() *mcp.Prompt {
+	return &mcp.Prompt{
+		Name: p.name,
+		Description: "Check if vulnerabilities (CVE, GHSA, RHSA, etc.) are detected in your StackRox-secured infrastructure. " +
+			"Supports comprehensive checking across Kubernetes/OpenShift components, deployments, and nodes. " +
+			"Can check single or multiple vulnerabilities, with optional scoping to specific clusters or workloads.",
+		Arguments: []*mcp.PromptArgument{
+			{
+				Name: "vuln_ids",
+				Description: "Vulnerability identifier(s) to check. Can be a single string (e.g., 'CVE-2021-44228') " +
+					"or an array of strings (e.g., ['CVE-2021-44228', 'GHSA-xxxx-xxxx-xxxx']). " +
+					"Supports CVE, GHSA, RHSA, and 20+ other vulnerability ID formats.",
+				Required: true,
+			},
+			{
+				Name: "scope",
+				Description: "Scope of the check. Options: 'fleet' (default - check across all clusters including orchestrator, " +
+					"deployments, and nodes), 'cluster' (check a specific cluster), 'workloads' (check only deployments/workloads).",
+				Required: false,
+			},
+			{
+				Name: "cluster_name",
+				Description: "Cluster name to filter by. Required when scope='cluster', optional for scope='workloads'. " +
+					"If cluster doesn't exist, the prompt will guide you to use list_clusters first.",
+				Required: false,
+			},
+			{
+				Name: "namespace_filter",
+				Description: "Namespace to filter by. Only applicable when checking workloads/deployments.",
+				Required: false,
+			},
+		},
+	}
+}
+
+func (p *checkVulnPrompt) GetMessages(arguments map[string]interface{}) ([]*mcp.PromptMessage, error) {
+	// Parse and validate input
+	vulnIDs, scope, clusterName, namespaceFilter, err := p.parseArguments(arguments)
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate appropriate message based on scope and number of vulnerabilities
+	content := p.buildMessageContent(vulnIDs, scope, clusterName, namespaceFilter)
+
+	return []*mcp.PromptMessage{
+		{
+			Role: "user",
+			Content: &mcp.TextContent{
+				Text: content,
+			},
+		},
+	}, nil
+}
+
+func (p *checkVulnPrompt) parseArguments(arguments map[string]interface{}) ([]string, string, string, string, error) {
+	// Parse vuln_ids (required)
+	vulnIDsRaw, ok := arguments["vuln_ids"]
+	if !ok {
+		return nil, "", "", "", errors.New("vuln_ids is required")
+	}
+
+	var vulnIDs []string
+	switch v := vulnIDsRaw.(type) {
+	case string:
+		if v == "" {
+			return nil, "", "", "", errors.New("vuln_ids cannot be empty")
+		}
+		vulnIDs = []string{v}
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, "", "", "", errors.New("vuln_ids cannot be empty")
+		}
+		for _, id := range v {
+			if str, ok := id.(string); ok && str != "" {
+				vulnIDs = append(vulnIDs, str)
+			}
+		}
+		if len(vulnIDs) == 0 {
+			return nil, "", "", "", errors.New("vuln_ids must contain at least one non-empty string")
+		}
+	case []string:
+		if len(v) == 0 {
+			return nil, "", "", "", errors.New("vuln_ids cannot be empty")
+		}
+		vulnIDs = v
+	default:
+		return nil, "", "", "", errors.New("vuln_ids must be a string or array of strings")
+	}
+
+	// Parse scope (optional, default to fleet)
+	scope := scopeFleet
+	if scopeRaw, ok := arguments["scope"].(string); ok && scopeRaw != "" {
+		scope = scopeRaw
+		if scope != scopeFleet && scope != scopeCluster && scope != scopeWorkloads {
+			return nil, "", "", "", fmt.Errorf("scope must be one of: %s, %s, %s", scopeFleet, scopeCluster, scopeWorkloads)
+		}
+	}
+
+	// Parse cluster_name (optional)
+	clusterName, _ := arguments["cluster_name"].(string)
+
+	// Validate cluster_name is provided when scope=cluster
+	if scope == scopeCluster && clusterName == "" {
+		return nil, "", "", "", errors.New("cluster_name is required when scope is 'cluster'")
+	}
+
+	// Parse namespace_filter (optional)
+	namespaceFilter, _ := arguments["namespace_filter"].(string)
+
+	return vulnIDs, scope, clusterName, namespaceFilter, nil
+}
+
+func (p *checkVulnPrompt) buildMessageContent(vulnIDs []string, scope, clusterName, namespaceFilter string) string {
+	var sb strings.Builder
+
+	// Header based on scope and count
+	if len(vulnIDs) == 1 {
+		sb.WriteString(fmt.Sprintf("You are checking if vulnerability %s is detected", vulnIDs[0]))
+	} else {
+		sb.WriteString(fmt.Sprintf("You are checking if vulnerabilities %s are detected", strings.Join(vulnIDs, ", ")))
+	}
+
+	switch scope {
+	case scopeCluster:
+		sb.WriteString(fmt.Sprintf(" in cluster %q.\n\n", clusterName))
+	case scopeWorkloads:
+		sb.WriteString(" in workloads/deployments")
+		if clusterName != "" {
+			sb.WriteString(fmt.Sprintf(" in cluster %q", clusterName))
+		}
+		if namespaceFilter != "" {
+			sb.WriteString(fmt.Sprintf(" in namespace %q", namespaceFilter))
+		}
+		sb.WriteString(".\n\n")
+	default: // fleet
+		sb.WriteString(" in the StackRox-secured cluster fleet.\n\n")
+	}
+
+	// Add workflow instructions
+	if len(vulnIDs) > 1 {
+		p.buildMultipleVulnWorkflow(&sb, vulnIDs, scope, clusterName, namespaceFilter)
+	} else {
+		p.buildSingleVulnWorkflow(&sb, vulnIDs[0], scope, clusterName, namespaceFilter)
+	}
+
+	return sb.String()
+}
+
+func (p *checkVulnPrompt) buildSingleVulnWorkflow(sb *strings.Builder, vulnID, scope, clusterName, namespaceFilter string) {
+	switch scope {
+	case scopeFleet:
+		sb.WriteString("Follow this comprehensive checking workflow:\n\n")
+		sb.WriteString("1. ORCHESTRATOR COMPONENTS CHECK:\n")
+		sb.WriteString(fmt.Sprintf("   - Use get_clusters_with_orchestrator_cve with cveName: %q\n", vulnID))
+		sb.WriteString("   - Checks Kubernetes/OpenShift components (API server, kubelet, etc.)\n\n")
+		sb.WriteString("2. DEPLOYMENT/WORKLOAD CHECK:\n")
+		sb.WriteString(fmt.Sprintf("   - Use get_deployments_for_cve with cveName: %q\n", vulnID))
+		sb.WriteString("   - Checks container images in application deployments\n\n")
+		sb.WriteString("3. NODE/HOST CHECK:\n")
+		sb.WriteString(fmt.Sprintf("   - Use get_nodes_for_cve with cveName: %q\n", vulnID))
+		sb.WriteString("   - Checks OS packages on cluster nodes\n\n")
+		sb.WriteString("IMPORTANT: Call ALL THREE tools for comprehensive coverage.\n")
+		sb.WriteString("Summarize which clusters/deployments/nodes are affected.\n")
+
+	case scopeCluster:
+		sb.WriteString("Follow this workflow:\n\n")
+		sb.WriteString("1. First, validate the cluster exists:\n")
+		sb.WriteString("   - Use list_clusters to check if the cluster exists\n")
+		sb.WriteString(fmt.Sprintf("   - If cluster %q not found, report it clearly\n\n", clusterName))
+		sb.WriteString("2. Then check all three locations WITH cluster filter:\n")
+		sb.WriteString(fmt.Sprintf("   - get_clusters_with_orchestrator_cve with cveName: %q and clusterName: %q\n", vulnID, clusterName))
+		sb.WriteString(fmt.Sprintf("   - get_deployments_for_cve with cveName: %q and clusterName: %q\n", vulnID, clusterName))
+		sb.WriteString(fmt.Sprintf("   - get_nodes_for_cve with cveName: %q and clusterName: %q\n\n", vulnID, clusterName))
+		sb.WriteString("Summarize which components/deployments/nodes are affected in this cluster.\n")
+
+	case scopeWorkloads:
+		sb.WriteString("Use get_deployments_for_cve with:\n")
+		sb.WriteString(fmt.Sprintf("- cveName: %q\n", vulnID))
+		if clusterName != "" {
+			sb.WriteString(fmt.Sprintf("- clusterName: %q\n", clusterName))
+		}
+		if namespaceFilter != "" {
+			sb.WriteString(fmt.Sprintf("- namespace: %q\n", namespaceFilter))
+		}
+		sb.WriteString("\nFocus on application deployments only.\n")
+		sb.WriteString("Report which deployments are affected.\n")
+	}
+}
+
+func (p *checkVulnPrompt) buildMultipleVulnWorkflow(sb *strings.Builder, vulnIDs []string, scope, clusterName, namespaceFilter string) {
+	sb.WriteString("For each vulnerability, perform the appropriate checks:\n\n")
+
+	if scope == scopeFleet {
+		sb.WriteString("For EACH vulnerability ID:\n")
+		sb.WriteString("1. Call get_clusters_with_orchestrator_cve (orchestrator components)\n")
+		sb.WriteString("2. Call get_deployments_for_cve (application deployments)\n")
+		sb.WriteString("3. Call get_nodes_for_cve (node OS packages)\n\n")
+		sb.WriteString("Present results grouped by vulnerability, showing which clusters/deployments/nodes\n")
+		sb.WriteString("are affected by each CVE.\n")
+	} else if scope == scopeCluster {
+		sb.WriteString(fmt.Sprintf("First, validate cluster %q exists using list_clusters.\n\n", clusterName))
+		sb.WriteString("Then for EACH vulnerability ID:\n")
+		sb.WriteString("1. Call get_clusters_with_orchestrator_cve with cluster filter\n")
+		sb.WriteString("2. Call get_deployments_for_cve with cluster filter\n")
+		sb.WriteString("3. Call get_nodes_for_cve with cluster filter\n\n")
+		sb.WriteString("Present results grouped by vulnerability.\n")
+	} else { // workloads
+		sb.WriteString("For EACH vulnerability ID, call get_deployments_for_cve with:\n")
+		sb.WriteString("- The specific vulnerability ID\n")
+		if clusterName != "" {
+			sb.WriteString(fmt.Sprintf("- clusterName: %q\n", clusterName))
+		}
+		if namespaceFilter != "" {
+			sb.WriteString(fmt.Sprintf("- namespace: %q\n", namespaceFilter))
+		}
+		sb.WriteString("\nPresent results grouped by vulnerability.\n")
+	}
+}
+
+func (p *checkVulnPrompt) RegisterWith(server *mcp.Server) {
+	server.AddPrompt(p.GetPrompt(), p.handle)
+}
+
+func (p *checkVulnPrompt) handle(
+	_ context.Context,
+	req *mcp.GetPromptRequest,
+) (*mcp.GetPromptResult, error) {
+	args := make(map[string]interface{})
+	if req.Params.Arguments != nil {
+		// Convert map[string]string to map[string]interface{}
+		for k, v := range req.Params.Arguments {
+			args[k] = v
+		}
+	}
+
+	messages, err := p.GetMessages(args)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcp.GetPromptResult{
+		Messages: messages,
+	}, nil
+}

--- a/internal/prompts/vulnerability/check_vuln_test.go
+++ b/internal/prompts/vulnerability/check_vuln_test.go
@@ -1,0 +1,409 @@
+package vulnerability
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCheckVulnPrompt(t *testing.T) {
+	prompt := NewCheckVulnPrompt()
+
+	require.NotNil(t, prompt)
+	assert.Equal(t, "check-vuln", prompt.GetName())
+}
+
+func TestCheckVulnPrompt_GetPrompt(t *testing.T) {
+	prompt := NewCheckVulnPrompt()
+
+	mcpPrompt := prompt.GetPrompt()
+
+	require.NotNil(t, mcpPrompt)
+	assert.Equal(t, "check-vuln", mcpPrompt.Name)
+	assert.NotEmpty(t, mcpPrompt.Description)
+	assert.Contains(t, mcpPrompt.Description, "vulnerabilities")
+	assert.Contains(t, mcpPrompt.Description, "CVE")
+
+	require.Len(t, mcpPrompt.Arguments, 4)
+
+	// Check vuln_ids argument
+	assert.Equal(t, "vuln_ids", mcpPrompt.Arguments[0].Name)
+	assert.True(t, mcpPrompt.Arguments[0].Required)
+
+	// Check scope argument
+	assert.Equal(t, "scope", mcpPrompt.Arguments[1].Name)
+	assert.False(t, mcpPrompt.Arguments[1].Required)
+
+	// Check clusterName argument
+	assert.Equal(t, "clusterName", mcpPrompt.Arguments[2].Name)
+	assert.False(t, mcpPrompt.Arguments[2].Required)
+
+	// Check namespaceFilter argument
+	assert.Equal(t, "namespaceFilter", mcpPrompt.Arguments[3].Name)
+	assert.False(t, mcpPrompt.Arguments[3].Required)
+}
+
+func TestCheckVulnPrompt_ParseVulnIDs(t *testing.T) {
+	prompt := &checkVulnPrompt{}
+
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		want      []string
+		wantErr   bool
+	}{
+		{
+			name: "single string CVE",
+			arguments: map[string]any{
+				"vuln_ids": "CVE-2021-44228",
+			},
+			want:    []string{"CVE-2021-44228"},
+			wantErr: false,
+		},
+		{
+			name: "array of strings",
+			arguments: map[string]any{
+				"vuln_ids": []any{"CVE-2021-44228", "CVE-2024-52577"},
+			},
+			want:    []string{"CVE-2021-44228", "CVE-2024-52577"},
+			wantErr: false,
+		},
+		{
+			name: "string array type",
+			arguments: map[string]any{
+				"vuln_ids": []string{"CVE-2021-44228", "GHSA-xxxx-xxxx-xxxx"},
+			},
+			want:    []string{"CVE-2021-44228", "GHSA-xxxx-xxxx-xxxx"},
+			wantErr: false,
+		},
+		{
+			name:      "missing vuln_ids",
+			arguments: map[string]any{},
+			wantErr:   true,
+		},
+		{
+			name: "empty string",
+			arguments: map[string]any{
+				"vuln_ids": "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty array",
+			arguments: map[string]any{
+				"vuln_ids": []any{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "array with empty strings",
+			arguments: map[string]any{
+				"vuln_ids": []any{"", ""},
+			},
+			wantErr: true,
+		},
+		{
+			name: "array with mixed valid and empty",
+			arguments: map[string]any{
+				"vuln_ids": []any{"CVE-2021-44228", "", "CVE-2024-52577"},
+			},
+			want:    []string{"CVE-2021-44228", "CVE-2024-52577"},
+			wantErr: false,
+		},
+		{
+			name: "invalid type",
+			arguments: map[string]any{
+				"vuln_ids": 123,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := prompt.parseVulnIDs(tt.arguments)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCheckVulnPrompt_ParseScope(t *testing.T) {
+	prompt := &checkVulnPrompt{}
+
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "default scope (missing)",
+			arguments: map[string]any{},
+			want:      "fleet",
+			wantErr:   false,
+		},
+		{
+			name: "explicit fleet scope",
+			arguments: map[string]any{
+				"scope": "fleet",
+			},
+			want:    "fleet",
+			wantErr: false,
+		},
+		{
+			name: "cluster scope",
+			arguments: map[string]any{
+				"scope": "cluster",
+			},
+			want:    "cluster",
+			wantErr: false,
+		},
+		{
+			name: "workloads scope",
+			arguments: map[string]any{
+				"scope": "workloads",
+			},
+			want:    "workloads",
+			wantErr: false,
+		},
+		{
+			name: "invalid scope",
+			arguments: map[string]any{
+				"scope": "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty scope defaults to fleet",
+			arguments: map[string]any{
+				"scope": "",
+			},
+			want:    "fleet",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := prompt.parseScope(tt.arguments)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCheckVulnPrompt_ValidateClusterName(t *testing.T) {
+	prompt := &checkVulnPrompt{}
+
+	tests := []struct {
+		name        string
+		scope       string
+		clusterName string
+		wantErr     bool
+	}{
+		{
+			name:        "cluster scope with name",
+			scope:       "cluster",
+			clusterName: "production",
+			wantErr:     false,
+		},
+		{
+			name:        "cluster scope without name",
+			scope:       "cluster",
+			clusterName: "",
+			wantErr:     true,
+		},
+		{
+			name:        "fleet scope without name",
+			scope:       "fleet",
+			clusterName: "",
+			wantErr:     false,
+		},
+		{
+			name:        "workloads scope without name",
+			scope:       "workloads",
+			clusterName: "",
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := prompt.validateClusterName(tt.scope, tt.clusterName)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCheckVulnPrompt_GetMessages_SingleVuln_Fleet(t *testing.T) {
+	prompt := NewCheckVulnPrompt()
+
+	args := map[string]any{
+		"vuln_ids": "CVE-2021-44228",
+		"scope":    "fleet",
+	}
+
+	messages, err := prompt.GetMessages(args)
+
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+
+	msg := messages[0]
+	assert.Equal(t, mcp.Role("user"), msg.Role)
+
+	textContent, ok := msg.Content.(*mcp.TextContent)
+	require.True(t, ok)
+
+	text := textContent.Text
+	assert.Contains(t, text, "CVE-2021-44228")
+	assert.Contains(t, text, "cluster fleet")
+	assert.Contains(t, text, "get_clusters_with_orchestrator_cve")
+	assert.Contains(t, text, "get_deployments_for_cve")
+	assert.Contains(t, text, "get_nodes_for_cve")
+	assert.Contains(t, text, "ALL THREE tools")
+}
+
+func TestCheckVulnPrompt_GetMessages_SingleVuln_Cluster(t *testing.T) {
+	prompt := NewCheckVulnPrompt()
+
+	args := map[string]any{
+		"vuln_ids":    "CVE-2021-44228",
+		"scope":       "cluster",
+		"clusterName": "production",
+	}
+
+	messages, err := prompt.GetMessages(args)
+
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+
+	textContent := messages[0].Content.(*mcp.TextContent)
+	text := textContent.Text
+
+	assert.Contains(t, text, "CVE-2021-44228")
+	assert.Contains(t, text, `cluster "production"`)
+	assert.Contains(t, text, "list_clusters")
+	assert.Contains(t, text, "WITH cluster filter")
+}
+
+func TestCheckVulnPrompt_GetMessages_SingleVuln_Workloads(t *testing.T) {
+	prompt := NewCheckVulnPrompt()
+
+	args := map[string]any{
+		"vuln_ids":        "CVE-2021-44228",
+		"scope":           "workloads",
+		"clusterName":     "production",
+		"namespaceFilter": "default",
+	}
+
+	messages, err := prompt.GetMessages(args)
+
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+
+	textContent := messages[0].Content.(*mcp.TextContent)
+	text := textContent.Text
+
+	assert.Contains(t, text, "CVE-2021-44228")
+	assert.Contains(t, text, "workloads/deployments")
+	assert.Contains(t, text, `cluster "production"`)
+	assert.Contains(t, text, `namespace "default"`)
+	assert.Contains(t, text, "get_deployments_for_cve")
+	assert.NotContains(t, text, "get_clusters_with_orchestrator_cve")
+	assert.NotContains(t, text, "get_nodes_for_cve")
+}
+
+func TestCheckVulnPrompt_GetMessages_MultipleVulns_Fleet(t *testing.T) {
+	prompt := NewCheckVulnPrompt()
+
+	args := map[string]any{
+		"vuln_ids": []string{"CVE-2021-44228", "CVE-2024-52577"},
+		"scope":    "fleet",
+	}
+
+	messages, err := prompt.GetMessages(args)
+
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+
+	textContent := messages[0].Content.(*mcp.TextContent)
+	text := textContent.Text
+
+	assert.Contains(t, text, "CVE-2021-44228")
+	assert.Contains(t, text, "CVE-2024-52577")
+	assert.Contains(t, text, "For EACH vulnerability ID")
+	assert.Contains(t, text, "grouped by vulnerability")
+}
+
+func TestCheckVulnPrompt_GetMessages_Errors(t *testing.T) {
+	prompt := NewCheckVulnPrompt()
+
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			name: "missing vuln_ids",
+			args: map[string]any{
+				"scope": "fleet",
+			},
+		},
+		{
+			name: "invalid scope",
+			args: map[string]any{
+				"vuln_ids": "CVE-2021-44228",
+				"scope":    "invalid",
+			},
+		},
+		{
+			name: "cluster scope without clusterName",
+			args: map[string]any{
+				"vuln_ids": "CVE-2021-44228",
+				"scope":    "cluster",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := prompt.GetMessages(tt.args)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestCheckVulnPrompt_RegisterWith(t *testing.T) {
+	prompt := NewCheckVulnPrompt()
+	server := mcp.NewServer(
+		&mcp.Implementation{
+			Name:    "test-server",
+			Version: "1.0.0",
+		},
+		&mcp.ServerOptions{},
+	)
+
+	// Should not panic
+	assert.NotPanics(t, func() {
+		prompt.RegisterWith(server)
+	})
+}

--- a/internal/prompts/vulnerability/check_vuln_test.go
+++ b/internal/prompts/vulnerability/check_vuln_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestNewCheckVulnPrompt(t *testing.T) {
+	t.Parallel()
+
 	prompt := NewCheckVulnPrompt()
 
 	require.NotNil(t, prompt)
@@ -16,6 +18,8 @@ func TestNewCheckVulnPrompt(t *testing.T) {
 }
 
 func TestCheckVulnPrompt_GetPrompt(t *testing.T) {
+	t.Parallel()
+
 	prompt := NewCheckVulnPrompt()
 
 	mcpPrompt := prompt.GetPrompt()
@@ -28,24 +32,22 @@ func TestCheckVulnPrompt_GetPrompt(t *testing.T) {
 
 	require.Len(t, mcpPrompt.Arguments, 4)
 
-	// Check vuln_ids argument
 	assert.Equal(t, "vuln_ids", mcpPrompt.Arguments[0].Name)
 	assert.True(t, mcpPrompt.Arguments[0].Required)
 
-	// Check scope argument
 	assert.Equal(t, "scope", mcpPrompt.Arguments[1].Name)
 	assert.False(t, mcpPrompt.Arguments[1].Required)
 
-	// Check clusterName argument
 	assert.Equal(t, "clusterName", mcpPrompt.Arguments[2].Name)
 	assert.False(t, mcpPrompt.Arguments[2].Required)
 
-	// Check namespaceFilter argument
 	assert.Equal(t, "namespaceFilter", mcpPrompt.Arguments[3].Name)
 	assert.False(t, mcpPrompt.Arguments[3].Required)
 }
 
 func TestCheckVulnPrompt_ParseVulnIDs(t *testing.T) {
+	t.Parallel()
+
 	prompt := &checkVulnPrompt{}
 
 	tests := []struct {
@@ -123,6 +125,8 @@ func TestCheckVulnPrompt_ParseVulnIDs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := prompt.parseVulnIDs(tt.arguments)
 
 			if tt.wantErr {
@@ -137,6 +141,8 @@ func TestCheckVulnPrompt_ParseVulnIDs(t *testing.T) {
 }
 
 func TestCheckVulnPrompt_ParseScope(t *testing.T) {
+	t.Parallel()
+
 	prompt := &checkVulnPrompt{}
 
 	tests := []struct {
@@ -148,31 +154,31 @@ func TestCheckVulnPrompt_ParseScope(t *testing.T) {
 		{
 			name:      "default scope (missing)",
 			arguments: map[string]any{},
-			want:      "fleet",
+			want:      ScopeFleet,
 			wantErr:   false,
 		},
 		{
 			name: "explicit fleet scope",
 			arguments: map[string]any{
-				"scope": "fleet",
+				"scope": ScopeFleet,
 			},
-			want:    "fleet",
+			want:    ScopeFleet,
 			wantErr: false,
 		},
 		{
 			name: "cluster scope",
 			arguments: map[string]any{
-				"scope": "cluster",
+				"scope": ScopeCluster,
 			},
-			want:    "cluster",
+			want:    ScopeCluster,
 			wantErr: false,
 		},
 		{
 			name: "workloads scope",
 			arguments: map[string]any{
-				"scope": "workloads",
+				"scope": ScopeWorkloads,
 			},
-			want:    "workloads",
+			want:    ScopeWorkloads,
 			wantErr: false,
 		},
 		{
@@ -187,13 +193,15 @@ func TestCheckVulnPrompt_ParseScope(t *testing.T) {
 			arguments: map[string]any{
 				"scope": "",
 			},
-			want:    "fleet",
+			want:    ScopeFleet,
 			wantErr: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := prompt.parseScope(tt.arguments)
 
 			if tt.wantErr {
@@ -208,6 +216,8 @@ func TestCheckVulnPrompt_ParseScope(t *testing.T) {
 }
 
 func TestCheckVulnPrompt_ValidateClusterName(t *testing.T) {
+	t.Parallel()
+
 	prompt := &checkVulnPrompt{}
 
 	tests := []struct {
@@ -218,25 +228,25 @@ func TestCheckVulnPrompt_ValidateClusterName(t *testing.T) {
 	}{
 		{
 			name:        "cluster scope with name",
-			scope:       "cluster",
+			scope:       ScopeCluster,
 			clusterName: "production",
 			wantErr:     false,
 		},
 		{
 			name:        "cluster scope without name",
-			scope:       "cluster",
+			scope:       ScopeCluster,
 			clusterName: "",
 			wantErr:     true,
 		},
 		{
 			name:        "fleet scope without name",
-			scope:       "fleet",
+			scope:       ScopeFleet,
 			clusterName: "",
 			wantErr:     false,
 		},
 		{
 			name:        "workloads scope without name",
-			scope:       "workloads",
+			scope:       ScopeWorkloads,
 			clusterName: "",
 			wantErr:     false,
 		},
@@ -244,6 +254,8 @@ func TestCheckVulnPrompt_ValidateClusterName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			err := prompt.validateClusterName(tt.scope, tt.clusterName)
 
 			if tt.wantErr {
@@ -256,11 +268,13 @@ func TestCheckVulnPrompt_ValidateClusterName(t *testing.T) {
 }
 
 func TestCheckVulnPrompt_GetMessages_SingleVuln_Fleet(t *testing.T) {
+	t.Parallel()
+
 	prompt := NewCheckVulnPrompt()
 
 	args := map[string]any{
 		"vuln_ids": "CVE-2021-44228",
-		"scope":    "fleet",
+		"scope":    ScopeFleet,
 	}
 
 	messages, err := prompt.GetMessages(args)
@@ -284,11 +298,13 @@ func TestCheckVulnPrompt_GetMessages_SingleVuln_Fleet(t *testing.T) {
 }
 
 func TestCheckVulnPrompt_GetMessages_SingleVuln_Cluster(t *testing.T) {
+	t.Parallel()
+
 	prompt := NewCheckVulnPrompt()
 
 	args := map[string]any{
 		"vuln_ids":    "CVE-2021-44228",
-		"scope":       "cluster",
+		"scope":       ScopeCluster,
 		"clusterName": "production",
 	}
 
@@ -307,11 +323,13 @@ func TestCheckVulnPrompt_GetMessages_SingleVuln_Cluster(t *testing.T) {
 }
 
 func TestCheckVulnPrompt_GetMessages_SingleVuln_Workloads(t *testing.T) {
+	t.Parallel()
+
 	prompt := NewCheckVulnPrompt()
 
 	args := map[string]any{
 		"vuln_ids":        "CVE-2021-44228",
-		"scope":           "workloads",
+		"scope":           ScopeWorkloads,
 		"clusterName":     "production",
 		"namespaceFilter": "default",
 	}
@@ -334,11 +352,13 @@ func TestCheckVulnPrompt_GetMessages_SingleVuln_Workloads(t *testing.T) {
 }
 
 func TestCheckVulnPrompt_GetMessages_MultipleVulns_Fleet(t *testing.T) {
+	t.Parallel()
+
 	prompt := NewCheckVulnPrompt()
 
 	args := map[string]any{
 		"vuln_ids": []string{"CVE-2021-44228", "CVE-2024-52577"},
-		"scope":    "fleet",
+		"scope":    ScopeFleet,
 	}
 
 	messages, err := prompt.GetMessages(args)
@@ -356,6 +376,8 @@ func TestCheckVulnPrompt_GetMessages_MultipleVulns_Fleet(t *testing.T) {
 }
 
 func TestCheckVulnPrompt_GetMessages_Errors(t *testing.T) {
+	t.Parallel()
+
 	prompt := NewCheckVulnPrompt()
 
 	tests := []struct {
@@ -365,7 +387,7 @@ func TestCheckVulnPrompt_GetMessages_Errors(t *testing.T) {
 		{
 			name: "missing vuln_ids",
 			args: map[string]any{
-				"scope": "fleet",
+				"scope": ScopeFleet,
 			},
 		},
 		{
@@ -379,13 +401,15 @@ func TestCheckVulnPrompt_GetMessages_Errors(t *testing.T) {
 			name: "cluster scope without clusterName",
 			args: map[string]any{
 				"vuln_ids": "CVE-2021-44228",
-				"scope":    "cluster",
+				"scope":    ScopeCluster,
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := prompt.GetMessages(tt.args)
 			assert.Error(t, err)
 		})
@@ -393,6 +417,8 @@ func TestCheckVulnPrompt_GetMessages_Errors(t *testing.T) {
 }
 
 func TestCheckVulnPrompt_RegisterWith(t *testing.T) {
+	t.Parallel()
+
 	prompt := NewCheckVulnPrompt()
 	server := mcp.NewServer(
 		&mcp.Implementation{
@@ -402,7 +428,6 @@ func TestCheckVulnPrompt_RegisterWith(t *testing.T) {
 		&mcp.ServerOptions{},
 	)
 
-	// Should not panic
 	assert.NotPanics(t, func() {
 		prompt.RegisterWith(server)
 	})

--- a/internal/prompts/vulnerability/promptset.go
+++ b/internal/prompts/vulnerability/promptset.go
@@ -1,0 +1,32 @@
+// Package vulnerability provides MCP prompts for vulnerability detection.
+package vulnerability
+
+import (
+	"github.com/stackrox/stackrox-mcp/internal/config"
+	"github.com/stackrox/stackrox-mcp/internal/prompts"
+)
+
+type promptset struct {
+	cfg *config.Config
+}
+
+// NewPromptset creates a new vulnerability management promptset.
+func NewPromptset(cfg *config.Config) prompts.Promptset {
+	return &promptset{
+		cfg: cfg,
+	}
+}
+
+func (p *promptset) GetName() string {
+	return "vulnerability"
+}
+
+func (p *promptset) IsEnabled() bool {
+	return p.cfg.Prompts.Vulnerability.Enabled
+}
+
+func (p *promptset) GetPrompts() []prompts.Prompt {
+	return []prompts.Prompt{
+		NewCheckVulnPrompt(),
+	}
+}

--- a/internal/prompts/vulnerability/promptset_test.go
+++ b/internal/prompts/vulnerability/promptset_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestNewPromptset(t *testing.T) {
+	t.Parallel()
+
 	cfg := &config.Config{
 		Prompts: config.PromptsConfig{
 			Vulnerability: config.PromptsVulnerabilityConfig{
@@ -24,6 +26,8 @@ func TestNewPromptset(t *testing.T) {
 }
 
 func TestPromptset_IsEnabled(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		enabled bool
@@ -40,6 +44,8 @@ func TestPromptset_IsEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cfg := &config.Config{
 				Prompts: config.PromptsConfig{
 					Vulnerability: config.PromptsVulnerabilityConfig{
@@ -56,6 +62,8 @@ func TestPromptset_IsEnabled(t *testing.T) {
 }
 
 func TestPromptset_GetPrompts(t *testing.T) {
+	t.Parallel()
+
 	cfg := &config.Config{
 		Prompts: config.PromptsConfig{
 			Vulnerability: config.PromptsVulnerabilityConfig{

--- a/internal/prompts/vulnerability/promptset_test.go
+++ b/internal/prompts/vulnerability/promptset_test.go
@@ -1,0 +1,73 @@
+package vulnerability
+
+import (
+	"testing"
+
+	"github.com/stackrox/stackrox-mcp/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPromptset(t *testing.T) {
+	cfg := &config.Config{
+		Prompts: config.PromptsConfig{
+			Vulnerability: config.PromptsVulnerabilityConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	promptset := NewPromptset(cfg)
+
+	require.NotNil(t, promptset)
+	assert.Equal(t, "vulnerability", promptset.GetName())
+}
+
+func TestPromptset_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{
+			name:    "enabled",
+			enabled: true,
+		},
+		{
+			name:    "disabled",
+			enabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Prompts: config.PromptsConfig{
+					Vulnerability: config.PromptsVulnerabilityConfig{
+						Enabled: tt.enabled,
+					},
+				},
+			}
+
+			promptset := NewPromptset(cfg)
+
+			assert.Equal(t, tt.enabled, promptset.IsEnabled())
+		})
+	}
+}
+
+func TestPromptset_GetPrompts(t *testing.T) {
+	cfg := &config.Config{
+		Prompts: config.PromptsConfig{
+			Vulnerability: config.PromptsVulnerabilityConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	promptset := NewPromptset(cfg)
+
+	prompts := promptset.GetPrompts()
+
+	require.Len(t, prompts, 1)
+	assert.Equal(t, "check-vuln", prompts[0].GetName())
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/pkg/errors"
 	"github.com/stackrox/stackrox-mcp/internal/config"
+	"github.com/stackrox/stackrox-mcp/internal/prompts"
 	"github.com/stackrox/stackrox-mcp/internal/toolsets"
 )
 
@@ -25,25 +26,32 @@ const (
 
 // Server represents the MCP HTTP server.
 type Server struct {
-	cfg      *config.Config
-	registry *toolsets.Registry
-	mcp      *mcp.Server
+	cfg            *config.Config
+	registry       *toolsets.Registry
+	promptRegistry *prompts.Registry
+	mcp            *mcp.Server
 }
 
 // NewServer creates a new MCP server instance.
-func NewServer(cfg *config.Config, registry *toolsets.Registry) *Server {
+func NewServer(cfg *config.Config, registry *toolsets.Registry, promptRegistry *prompts.Registry) *Server {
 	mcpServer := mcp.NewServer(
 		&mcp.Implementation{
 			Name:    config.GetServerName(),
 			Version: config.GetVersion(),
 		},
-		nil,
+		&mcp.ServerOptions{
+			Capabilities: &mcp.ServerCapabilities{
+				Tools:   &mcp.ToolCapabilities{},
+				Prompts: &mcp.PromptCapabilities{},
+			},
+		},
 	)
 
 	return &Server{
-		cfg:      cfg,
-		registry: registry,
-		mcp:      mcpServer,
+		cfg:            cfg,
+		registry:       registry,
+		promptRegistry: promptRegistry,
+		mcp:            mcpServer,
 	}
 }
 
@@ -52,6 +60,7 @@ func NewServer(cfg *config.Config, registry *toolsets.Registry) *Server {
 // If they are nil, os.Stdin/os.Stdout will be used.
 func (s *Server) Start(ctx context.Context, stdin io.ReadCloser, stdout io.WriteCloser) error {
 	s.registerTools()
+	s.registerPrompts()
 
 	if s.cfg.Server.Type == config.ServerTypeStdio {
 		return s.startStdio(ctx, stdin, stdout)
@@ -177,4 +186,25 @@ func (s *Server) registerTools() {
 	}
 
 	slog.Info("Tools registration complete")
+}
+
+// registerPrompts registers all prompts from the registry with the MCP server.
+func (s *Server) registerPrompts() {
+	slog.Info("Registering MCP prompts")
+
+	for _, promptset := range s.promptRegistry.GetPromptsets() {
+		if !promptset.IsEnabled() {
+			slog.Info("Skipping disabled promptset", "promptset", promptset.GetName())
+
+			continue
+		}
+
+		for _, prompt := range promptset.GetPrompts() {
+			slog.Info("Registering prompt", "promptset", promptset.GetName(), "prompt", prompt.GetName())
+
+			prompt.RegisterWith(s.mcp)
+		}
+	}
+
+	slog.Info("Prompts registration complete")
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stackrox/stackrox-mcp/internal/config"
+	"github.com/stackrox/stackrox-mcp/internal/prompts"
 	"github.com/stackrox/stackrox-mcp/internal/testutil"
 	"github.com/stackrox/stackrox-mcp/internal/toolsets"
 	"github.com/stackrox/stackrox-mcp/internal/toolsets/mock"
@@ -38,6 +39,14 @@ func getDefaultConfig() *config.Config {
 				Enabled: false,
 			},
 		},
+		Prompts: config.PromptsConfig{
+			Vulnerability: config.PromptsVulnerabilityConfig{
+				Enabled: false,
+			},
+			ConfigManager: config.PromptsConfigManagerConfig{
+				Enabled: false,
+			},
+		},
 	}
 }
 
@@ -45,12 +54,14 @@ func TestNewServer(t *testing.T) {
 	cfg := getDefaultConfig()
 
 	registry := toolsets.NewRegistry(cfg, []toolsets.Toolset{})
+	promptRegistry := prompts.NewRegistry(cfg, []prompts.Promptset{})
 
-	srv := NewServer(cfg, registry)
+	srv := NewServer(cfg, registry, promptRegistry)
 
 	require.NotNil(t, srv)
 	assert.Equal(t, cfg, srv.cfg)
 	assert.Equal(t, registry, srv.registry)
+	assert.Equal(t, promptRegistry, srv.promptRegistry)
 	assert.NotNil(t, srv.mcp)
 }
 
@@ -66,7 +77,8 @@ func TestServer_registerTools_AllEnabled(t *testing.T) {
 	}
 
 	registry := toolsets.NewRegistry(cfg, toolsetList)
-	srv := NewServer(cfg, registry)
+	promptRegistry := prompts.NewRegistry(cfg, []prompts.Promptset{})
+	srv := NewServer(cfg, registry, promptRegistry)
 
 	srv.registerTools()
 
@@ -86,7 +98,8 @@ func TestServer_registerTools_ReadOnlyMode(t *testing.T) {
 	}
 
 	registry := toolsets.NewRegistry(cfg, toolsetList)
-	srv := NewServer(cfg, registry)
+	promptRegistry := prompts.NewRegistry(cfg, []prompts.Promptset{})
+	srv := NewServer(cfg, registry, promptRegistry)
 
 	srv.registerTools()
 
@@ -107,7 +120,8 @@ func TestServer_registerTools_DisabledToolset(t *testing.T) {
 	}
 
 	registry := toolsets.NewRegistry(cfg, toolsetList)
-	srv := NewServer(cfg, registry)
+	promptRegistry := prompts.NewRegistry(cfg, []prompts.Promptset{})
+	srv := NewServer(cfg, registry, promptRegistry)
 
 	srv.registerTools()
 
@@ -126,7 +140,8 @@ func TestServer_Start(t *testing.T) {
 	}
 
 	registry := toolsets.NewRegistry(cfg, toolsetList)
-	srv := NewServer(cfg, registry)
+	promptRegistry := prompts.NewRegistry(cfg, []prompts.Promptset{})
+	srv := NewServer(cfg, registry, promptRegistry)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -172,7 +187,8 @@ func TestServer_HealthEndpoint(t *testing.T) {
 	cfg.Server.Port = testutil.GetPortForTest(t)
 
 	registry := toolsets.NewRegistry(cfg, []toolsets.Toolset{})
-	srv := NewServer(cfg, registry)
+	promptRegistry := prompts.NewRegistry(cfg, []prompts.Promptset{})
+	srv := NewServer(cfg, registry, promptRegistry)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Add MCP prompts infrastructure to guide LLMs in performing comprehensive vulnerability detection workflows. Without prompts, LLMs may only call one tool (e.g., just deployments) missing coverage across orchestrator components, deployments, and nodes.

Implement two prompts:
- check-vuln: Flexible vulnerability detection with scope-based workflows
  (fleet/cluster/workloads) supporting single or multiple CVE checks
- list-cluster: Simple cluster inventory prompt

The prompts provide explicit workflows ensuring consistent, complete vulnerability assessment across all infrastructure layers.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>### Description

<!-- Please provide information on what this PR changes. -->

### Validation

```markdown
❯ /mcp__stackrox-mcp__list-cluster

● I'll help you list all the Kubernetes/OpenShift clusters secured by StackRox Central.

● stackrox-mcp - list_clusters (MCP)
  ⎿  {
       "clusters": [
         {
     … +29 lines (ctrl+o to expand)

● StackRox Secured Clusters

  Found 5 clusters managed by StackRox Central:

  ┌─────────────────┬──────────────────────────────────────┬────────────────────┐
  │  Cluster Name   │              Cluster ID              │        Type        │
  ├─────────────────┼──────────────────────────────────────┼────────────────────┤
  │ acs-int-us-02   │ e8349cfc-af25-43d0-ab6e-6e104efc1647 │ OPENSHIFT4_CLUSTER │
  ├─────────────────┼──────────────────────────────────────┼────────────────────┤
  │ acs-prod-dp-02  │ 836f3b11-04f0-4068-a76e-b1122f6bcb3d │ OPENSHIFT4_CLUSTER │
  ├─────────────────┼──────────────────────────────────────┼────────────────────┤
  │ acs-prod-eu-02  │ 3dbdaad9-9d02-4dd0-8cb5-c1e9c9f2ab22 │ OPENSHIFT4_CLUSTER │
  ├─────────────────┼──────────────────────────────────────┼────────────────────┤
  │ acs-stage-dp-03 │ 37da3ba5-c487-48c5-9e3c-3bf60d13df64 │ OPENSHIFT4_CLUSTER │
  ├─────────────────┼──────────────────────────────────────┼────────────────────┤
  │ acs-stage-eu-03 │ 1ef7e609-d9fa-47d6-a8d5-162c87d4a216 │ OPENSHIFT4_CLUSTER │
  └─────────────────┴──────────────────────────────────────┴────────────────────┘

  All clusters are running OpenShift 4.

❯ /mcp__stackrox-mcp__list-cluster CVE-2024-25621

● I see you've provided a CVE identifier. Let me fetch the tool to find clusters affected by this specific CVE.

● I'll check for CVE-2024-25621 across all areas: orchestrator components, deployments, and nodes.

● stackrox-mcp - get_clusters_with_orchestrator_cve (MCP)(cveName: "CVE-2024-25621")
  ⎿  {
       "clusters": []
     }

● stackrox-mcp - get_deployments_for_cve (MCP)(cveName: "CVE-2024-25621")
  ⎿  {"deployments":[{"clusterId":"e8349cfc-af25-43d0-ab6e-6e104efc1647","clusterName":"acs-int-us-02","name":"ovnkube-node","namespace":"
     openshift-ovn-kubernetes"},{"clusterId":"836f3b11-04f0-4068-a76e-b1122f6bcb3d","clusterName":"acs-prod-dp-02","name":"node-resolver",
     "namespace":"openshift-dns"},{"clusterId":"3dbdaad9-9d02-4dd0-8cb5-c1e9c9f2ab22","clusterName":"acs-prod-eu-02","name":"node-resolver
     … +115 lines (ctrl+o to expand)

● stackrox-mcp - get_nodes_for_cve (MCP)(cveName: "CVE-2024-25621")
  ⎿  {
       "nodeGroups": [
         {
     … +31 lines (ctrl+o to expand)

● CVE-2024-25621 Detection Report

  Summary: CVE-2024-25621 is detected across all 5 clusters in deployments and node operating systems.

  Affected Areas

  ┌─────────────────────────┬──────────────────────────────┐
  │          Area           │            Status            │
  ├─────────────────────────┼──────────────────────────────┤
  │ Orchestrator Components │ ✓ Not detected               │
  ├─────────────────────────┼──────────────────────────────┤
  │ Deployments             │ ⚠️ 100+ deployments affected │
  ├─────────────────────────┼──────────────────────────────┤
  │ Nodes                   │ ⚠️ All clusters affected     │
  └─────────────────────────┴──────────────────────────────┘

  ---
  Cluster Breakdown

  ┌─────────────────┬─────────────┬────────────────┬────────────────────────────┐
  │     Cluster     │ Deployments │ Nodes Affected │          Node OS           │
  ├─────────────────┼─────────────┼────────────────┼────────────────────────────┤
  │ acs-int-us-02   │ Multiple    │ 11 nodes       │ RHEL CoreOS 9.6.20260314-0 │
  ├─────────────────┼─────────────┼────────────────┼────────────────────────────┤
  │ acs-prod-dp-02  │ Multiple    │ 42 nodes       │ RHEL CoreOS 9.6.20260303-1 │
  ├─────────────────┼─────────────┼────────────────┼────────────────────────────┤
  │ acs-prod-eu-02  │ Multiple    │ 22 nodes       │ RHEL CoreOS 9.6.20260303-1 │
  ├─────────────────┼─────────────┼────────────────┼────────────────────────────┤
  │ acs-stage-dp-03 │ Multiple    │ 17 nodes       │ RHEL CoreOS 9.6.20260303-1 │
  ├─────────────────┼─────────────┼────────────────┼────────────────────────────┤
  │ acs-stage-eu-03 │ Multiple    │ 14 nodes       │ RHEL CoreOS 9.6.20260303-1 │
  └─────────────────┴─────────────┴────────────────┴────────────────────────────┘

  Total: 106 nodes affected

  ---
  Affected Deployment Types

  The vulnerability is primarily detected in OpenShift platform components:

  - Networking: ovnkube-node, ovnkube-control-plane, node-resolver, iptables-alerter, network-node-identity
  - Operator Lifecycle: catalog-operator, olm-operator, packageserver, catalogd-controller-manager
  - Maintenance/SRE: builds-pruner, deployments-pruner, image-pruner, osd-* utilities
  - Marketplace: redhat-marketplace-*, certified-operators-*, community-operators-*

  All clusters show consistent patterns of affected deployments in openshift-* namespaces.
  ```
