### PR TITLE
chore(CI): Debug artifact download

### DIFF
--- a/.github/workflows/model-evaluation.yml
+++ b/.github/workflows/model-evaluation.yml
@@ -87,18 +87,20 @@ jobs:
       - name: Download all results
         uses: actions/download-artifact@v8
         with:
-          # Download all artifacts instead of using pattern matching.
-          # When pattern matches a single artifact, download-artifact extracts
-          # it directly into the path without creating a subdirectory, breaking
-          # the expected path structure. Downloading all artifacts always creates
-          # per-artifact subdirectories.
+          pattern: eval-results-*
           path: eval-results
 
       - name: Update model evaluation docs
         run: |
           MODELS="${{ inputs.models || 'gpt-5-mini' }}"
           for MODEL in $(echo "$MODELS" | tr ',' ' '); do
+            # download-artifact@v8 creates per-artifact subdirectories only when
+            # multiple artifacts are downloaded. With a single artifact it extracts
+            # directly into the target path. Check both locations.
             RESULTS_FILE="eval-results/eval-results-${MODEL}/mcpchecker-stackrox-mcp-e2e-out.json"
+            if [ ! -f "$RESULTS_FILE" ]; then
+              RESULTS_FILE="eval-results/mcpchecker-stackrox-mcp-e2e-out.json"
+            fi
             if [ -f "$RESULTS_FILE" ]; then
               echo "Updating docs for model: ${MODEL}"
               ./scripts/update-model-evaluation.sh \


### PR DESCRIPTION
### Description

Fixes the `download-artifact` path issue in the model-evaluation workflow and adds debug tooling. `download-artifact@v8` extracts a single artifact directly into the target path without creating a per-artifact subdirectory, breaking the expected path `eval-results/eval-results-<model>/...`. Fixed by checking both possible file locations: the subdirectory path (multiple artifacts) and the flat path (single artifact).

### Validation

- [x] `actionlint` passes on the modified workflow file
- [x] Verify artifact directory structure in CI logs - https://github.com/stackrox/stackrox-mcp/actions/runs/24250717708/job/70810127752
```
=== eval-results directory structure ===
eval-results:
mcpchecker-stackrox-mcp-e2e-out.json
```

### AI-assisted development prompts

This PR was developed with AI assistance. Below are the prompts used:

> **Prompt:** "This still does not work. I get: 'Warning: No results found for model gpt-5-mini'. But everything is downloaded properly. We need to test this somehow on a PR. Let's disable temporally creation of PR. List files and trigger it on PR. Research problem and prepare ticket to implement solution."
> **Response:** Added temporary `pull_request` trigger, debug `ls -R eval-results` step, and commented out the PR creation step. Created beads task for the investigation.

> **Prompt:** "This is what we got: eval-results: mcpchecker-stackrox-mcp-e2e-out.json"
> **Response:** Confirmed that `download-artifact@v8` places a single artifact flat at the target path with no subdirectory. Created fix ticket `stackrox-mcp-ovo` to handle both path layouts.

> **Prompt:** "do it" (implement the fix)
> **Response:** Applied the fix: checks subdirectory path first, falls back to flat path. Reverted all debug changes (removed `pull_request` trigger, debug step, restored PR creation).

> **Prompt:** "Let's also put pattern matching back"
> **Response:** Restored `pattern: eval-results-*` to the download-artifact step.