### PR TITLE
ROX-32888: Use ACS bot token to create PR

### DIFF
--- a/.github/workflows/model-evaluation.yml
+++ b/.github/workflows/model-evaluation.yml
@@ -2,7 +2,7 @@ name: Weekly Model Evaluation
 
 on:
   schedule:
-    - cron: '0 6 * * 1' # Every Monday at 6:00 UTC
+    - cron: '0 6 * * 2' # Every Tuesday at 6:00 UTC
   workflow_dispatch:
     inputs:
       models:
@@ -127,6 +127,7 @@ jobs:
         if: steps.check-changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
           branch: chore/update-model-evaluation-${{ needs.prepare.outputs.date }}
           commit-message: "Update model evaluations ${{ needs.prepare.outputs.date }}"
           title: "chore(evals): Update model evaluations ${{ needs.prepare.outputs.date }}"


### PR DESCRIPTION
### Description

Uses `RHACS_BOT_GITHUB_TOKEN` instead of the default `GITHUB_TOKEN` in the `peter-evans/create-pull-request` step of the model-evaluation workflow. PRs created with the default token do not trigger `pull_request` workflows (GitHub's design to prevent infinite loops), which meant required CI checks (build, test, e2e, style, smoke, wiremock-test) were not running on auto-generated evaluation PRs.

Also changes the weekly schedule from Monday to Tuesday at 6:00 UTC - to test trigger.

### Validation

- [x] `actionlint` passes on the modified workflow file
- [x] Verify CI checks trigger on the next auto-generated evaluation PR **(after merge)**

### AI-assisted development prompts

This PR was developed with AI assistance. Below are the prompts used:

> **Prompt:** "Weekly job is running now, but we have a problem that created PR is not running tests. Here is an example: https://github.com/stackrox/stackrox-mcp/pull/114 - if you investigate that PR, you will see that required tests are not triggered. What should be done to fix that?"
> **Response:** Identified the root cause: `peter-evans/create-pull-request` using the default `GITHUB_TOKEN` does not trigger `pull_request` workflows. Recommended using a PAT or GitHub App token instead.

> **Prompt:** "Ok. I have token in secret: RHACS_BOT_GITHUB_TOKEN - use that"
> **Response:** Added `token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}` to the Create Pull Request step.

> **Prompt:** "Let's switch to Tuesday - so that we can test it next day."
> **Response:** Changed cron schedule from `0 6 * * 1` (Monday) to `0 6 * * 2` (Tuesday).