### PR TITLE
ROX-33010: Add MCP Gateway integraton to Helm chart

### DIFF
--- a/charts/stackrox-mcp/README.md
+++ b/charts/stackrox-mcp/README.md
@@ -142,6 +142,18 @@ The following table lists the configurable parameters of the StackRox MCP chart 
 | `openshift.route.tls.insecureEdgeTerminationPolicy` | Policy for insecure edge traffic | `Redirect` |
 | `openshift.route.tls.destinationCACertificate` | CA certificate for pod verification | `""` |
 
+### MCP Gateway Integration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `mcpGateway.enabled` | Enable MCP Gateway integration | `false` |
+| `mcpGateway.gateway.name` | Name of the MCP Gateway resource | `stackrox-mcp-gateway` |
+| `mcpGateway.gateway.namespace` | Namespace of the MCP Gateway resource | `gateway-system` |
+| `mcpGateway.hostname` | Hostname for the HTTPRoute | `""` |
+| `mcpGateway.toolPrefix` | Prefix for tools exposed via the gateway | `stackrox_` |
+
+**Note:** Requires [MCP Gateway](https://github.com/Kuadrant/mcp-gateway) to be installed on the cluster. The chart validates that the required CRDs (`gateway.networking.k8s.io/v1/HTTPRoute` and `mcp.kagenti.com/v1alpha1/MCPServerRegistration`) are available and fails with a descriptive error if they are not. See [MCP Gateway Integration](../../docs/mcp-gateway-integration.md) for details.
+
 ### Scheduling
 
 | Parameter | Description | Default |

--- a/charts/stackrox-mcp/README.md
+++ b/charts/stackrox-mcp/README.md
@@ -147,12 +147,12 @@ The following table lists the configurable parameters of the StackRox MCP chart 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `mcpGateway.enabled` | Enable MCP Gateway integration | `false` |
-| `mcpGateway.gateway.name` | Name of the MCP Gateway resource | `stackrox-mcp-gateway` |
+| `mcpGateway.gateway.name` | Name of the MCP Gateway resource | `mcp-gateway` |
 | `mcpGateway.gateway.namespace` | Namespace of the MCP Gateway resource | `gateway-system` |
-| `mcpGateway.hostname` | Hostname for the HTTPRoute | `""` |
+| `mcpGateway.hostname` | Internal routing hostname for the HTTPRoute | `<fullname>.mcp.local` |
 | `mcpGateway.toolPrefix` | Prefix for tools exposed via the gateway | `stackrox_` |
 
-**Note:** Requires [MCP Gateway](https://github.com/Kuadrant/mcp-gateway) to be installed on the cluster. The chart validates that the required CRDs (`gateway.networking.k8s.io/v1/HTTPRoute` and `mcp.kagenti.com/v1alpha1/MCPServerRegistration`) are available and fails with a descriptive error if they are not. See [MCP Gateway Integration](../../docs/mcp-gateway-integration.md) for details.
+**Note:** Requires [MCP Gateway](https://github.com/Kuadrant/mcp-gateway) to be installed on the cluster. The chart validates that the required CRDs (`gateway.networking.k8s.io/v1/HTTPRoute` and `mcp.kuadrant.io/v1alpha1/MCPServerRegistration`) are available and fails with a descriptive error if they are not. When MCP Gateway is enabled, `replicaCount` must be set to `1` — the Gateway API's HTTPRoute bypasses Service-level session affinity, so multiple replicas would break stateful MCP sessions. See [MCP Gateway Integration](../../docs/mcp-gateway-integration.md) for details.
 
 ### Scheduling
 
@@ -362,6 +362,8 @@ helm install stackrox-mcp charts/stackrox-mcp \
 **Warning:** Self-signed certificates should only be used for testing. For production, use certificates from a trusted Certificate Authority.
 
 ### High Availability Setup
+
+**Note:** High availability with multiple replicas is not supported when MCP Gateway is enabled (`mcpGateway.enabled=true`). See [MCP Gateway Integration](#mcp-gateway-integration) for details.
 
 For high availability with multiple replicas:
 

--- a/charts/stackrox-mcp/templates/_helpers.tpl
+++ b/charts/stackrox-mcp/templates/_helpers.tpl
@@ -46,7 +46,7 @@ Image reference
 */}}
 {{- define "stackrox-mcp.image" -}}
 {{- $tag := .Values.image.tag | default .Chart.AppVersion }}
-{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository $tag }}
+{{- print .Values.image.registry "/" .Values.image.repository ":" $tag }}
 {{- end }}
 
 {{/*

--- a/charts/stackrox-mcp/templates/http-route.yaml
+++ b/charts/stackrox-mcp/templates/http-route.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.mcpGateway.enabled }}
+{{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1/HTTPRoute") }}
+{{- fail "MCP Gateway integration requires the Gateway API (gateway.networking.k8s.io/v1/HTTPRoute). Install Gateway API CRDs before enabling mcpGateway." }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "stackrox-mcp.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "stackrox-mcp.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+  - name: {{ .Values.mcpGateway.gateway.name }}
+    namespace: {{ .Values.mcpGateway.gateway.namespace }}
+  {{- with .Values.mcpGateway.hostname }}
+  hostnames:
+  - {{ . | quote }}
+  {{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /mcp
+    backendRefs:
+    - name: {{ include "stackrox-mcp.fullname" . }}
+      port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/stackrox-mcp/templates/http-route.yaml
+++ b/charts/stackrox-mcp/templates/http-route.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.mcpGateway.enabled }}
+{{- if gt (int .Values.replicaCount) 1 }}
+{{- fail "When MCP Gateway is enabled (mcpGateway.enabled=true), replicaCount must be set to 1. Multiple replicas will cause MCP client connections to land on different pods, breaking stateful MCP sessions. Set replicaCount=1 in your values." }}
+{{- end }}
 {{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1/HTTPRoute") }}
 {{- fail "MCP Gateway integration requires the Gateway API (gateway.networking.k8s.io/v1/HTTPRoute). Install Gateway API CRDs before enabling mcpGateway." }}
 {{- end }}
@@ -13,10 +16,8 @@ spec:
   parentRefs:
   - name: {{ .Values.mcpGateway.gateway.name }}
     namespace: {{ .Values.mcpGateway.gateway.namespace }}
-  {{- with .Values.mcpGateway.hostname }}
   hostnames:
-  - {{ . | quote }}
-  {{- end }}
+  - {{ .Values.mcpGateway.hostname | default (printf "%s.mcp.local" (include "stackrox-mcp.fullname" .)) | quote }}
   rules:
   - matches:
     - path:

--- a/charts/stackrox-mcp/templates/mcp-server-registration.yaml
+++ b/charts/stackrox-mcp/templates/mcp-server-registration.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.mcpGateway.enabled }}
+{{- if not (.Capabilities.APIVersions.Has "mcp.kagenti.com/v1alpha1/MCPServerRegistration") }}
+{{- fail "MCP Gateway integration requires the MCPServerRegistration CRD (mcp.kagenti.com/v1alpha1/MCPServerRegistration). Install MCP Gateway (https://github.com/Kuadrant/mcp-gateway) before enabling mcpGateway." }}
+{{- end }}
+apiVersion: mcp.kagenti.com/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: {{ include "stackrox-mcp.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "stackrox-mcp.labels" . | nindent 4 }}
+spec:
+  toolPrefix: {{ .Values.mcpGateway.toolPrefix }}
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: {{ include "stackrox-mcp.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/stackrox-mcp/templates/mcp-server-registration.yaml
+++ b/charts/stackrox-mcp/templates/mcp-server-registration.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.mcpGateway.enabled }}
-{{- if not (.Capabilities.APIVersions.Has "mcp.kagenti.com/v1alpha1/MCPServerRegistration") }}
-{{- fail "MCP Gateway integration requires the MCPServerRegistration CRD (mcp.kagenti.com/v1alpha1/MCPServerRegistration). Install MCP Gateway (https://github.com/Kuadrant/mcp-gateway) before enabling mcpGateway." }}
+{{- if not (.Capabilities.APIVersions.Has "mcp.kuadrant.io/v1alpha1/MCPServerRegistration") }}
+{{- fail "MCP Gateway integration requires the MCPServerRegistration CRD (mcp.kuadrant.io/v1alpha1/MCPServerRegistration). Install MCP Gateway (https://github.com/Kuadrant/mcp-gateway) before enabling mcpGateway." }}
 {{- end }}
-apiVersion: mcp.kagenti.com/v1alpha1
+apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:
   name: {{ include "stackrox-mcp.fullname" . }}

--- a/charts/stackrox-mcp/templates/mcp-server-registration.yaml
+++ b/charts/stackrox-mcp/templates/mcp-server-registration.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     {{- include "stackrox-mcp.labels" . | nindent 4 }}
 spec:
-  toolPrefix: {{ .Values.mcpGateway.toolPrefix }}
+  toolPrefix: {{ .Values.mcpGateway.toolPrefix | quote }}
   targetRef:
     group: gateway.networking.k8s.io
     kind: HTTPRoute

--- a/charts/stackrox-mcp/values.yaml
+++ b/charts/stackrox-mcp/values.yaml
@@ -184,6 +184,22 @@ config:
     configManager:
       enabled: true
 
+# MCP Gateway integration (opt-in)
+# Requires MCP Gateway (https://github.com/Kuadrant/mcp-gateway) to be installed on the cluster
+mcpGateway:
+  enabled: false
+
+  # Gateway resource reference
+  gateway:
+    name: stackrox-mcp-gateway
+    namespace: gateway-system
+
+  # Hostname for the HTTPRoute
+  hostname: ""
+
+  # Tool prefix to avoid naming conflicts when aggregating tools through the gateway
+  toolPrefix: stackrox_
+
 # Additional environment variables (advanced use)
 # These will be added directly to the container
 extraEnv: []

--- a/charts/stackrox-mcp/values.yaml
+++ b/charts/stackrox-mcp/values.yaml
@@ -189,9 +189,9 @@ config:
 mcpGateway:
   enabled: false
 
-  # Gateway resource reference
+  # Main MCP Gateway reference (this is usually Gateway that gathers all MCP servers)
   gateway:
-    name: stackrox-mcp-gateway
+    name: mcp-gateway
     namespace: gateway-system
 
   # Hostname for the HTTPRoute

--- a/docs/mcp-gateway-integration.md
+++ b/docs/mcp-gateway-integration.md
@@ -1,0 +1,59 @@
+# MCP Gateway Integration
+
+This guide describes how to integrate the StackRox MCP server with [MCP Gateway](https://github.com/Kuadrant/mcp-gateway), enabling tool aggregation behind a centralized gateway endpoint.
+
+## Overview
+
+MCP Gateway is an Envoy-based system that aggregates multiple MCP servers behind a single endpoint. It uses Gateway API resources and a custom `MCPServerRegistration` CRD to discover and route requests to backend MCP servers.
+
+When enabled, the Helm chart creates:
+- **HTTPRoute** — routes `/mcp` traffic from the gateway to the StackRox MCP service
+- **MCPServerRegistration** — registers the server with the gateway using a tool prefix to avoid naming conflicts
+
+## Prerequisites
+
+- [MCP Gateway](https://github.com/Kuadrant/mcp-gateway) installed on the cluster ([OpenShift installation guide](https://github.com/Kuadrant/mcp-gateway/tree/main/config/openshift))
+
+The Helm chart validates that the required CRDs are available and fails with a descriptive error if they are not.
+
+## Installation
+
+```bash
+helm install stackrox-mcp charts/stackrox-mcp \
+  --namespace stackrox-mcp \
+  --create-namespace \
+  --set mcpGateway.enabled=true \
+  --set mcpGateway.hostname=stackrox-mcp.mcp.local \
+  --set config.central.url=<your-central-url>
+```
+
+## Configuration Reference
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `mcpGateway.enabled` | Enable MCP Gateway integration | `false` |
+| `mcpGateway.gateway.name` | Name of the MCP Gateway resource | `stackrox-mcp-gateway` |
+| `mcpGateway.gateway.namespace` | Namespace of the MCP Gateway resource | `gateway-system` |
+| `mcpGateway.hostname` | Hostname for the HTTPRoute | `""` |
+| `mcpGateway.toolPrefix` | Prefix for tools exposed via the gateway | `stackrox_` |
+
+## Verification
+
+```bash
+curl -X POST https://$(oc get routes -n gateway-system -o jsonpath='{ .items[0].spec.host }')/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+```
+
+## Architecture
+
+```
+MCP Client
+  → MCP Gateway (gateway-system namespace)
+    → HTTPRoute (/mcp)
+      → StackRox MCP Service (stackrox-mcp namespace)
+        → StackRox MCP Pod(s)
+          → StackRox Central API
+```
+
+The gateway aggregates tools from all registered MCP servers. StackRox MCP tools are exposed with the configured prefix (e.g., `stackrox_get_deployments_for_cve`).

--- a/docs/mcp-gateway-integration.md
+++ b/docs/mcp-gateway-integration.md
@@ -18,10 +18,13 @@ The Helm chart validates that the required CRDs are available and fails with a d
 
 ## Installation
 
+**Important:** When MCP Gateway is enabled, `replicaCount` must be set to `1`. The Gateway API's HTTPRoute bypasses Kubernetes Service-level session affinity, so multiple replicas would cause MCP client connections to land on different pods, breaking stateful MCP sessions.
+
 ```bash
 helm install stackrox-mcp charts/stackrox-mcp \
   --namespace stackrox-mcp \
   --create-namespace \
+  --set replicaCount=1 \
   --set mcpGateway.enabled=true \
   --set mcpGateway.hostname=stackrox-mcp.mcp.local \
   --set config.central.url=<your-central-url>
@@ -32,9 +35,9 @@ helm install stackrox-mcp charts/stackrox-mcp \
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `mcpGateway.enabled` | Enable MCP Gateway integration | `false` |
-| `mcpGateway.gateway.name` | Name of the MCP Gateway resource | `stackrox-mcp-gateway` |
+| `mcpGateway.gateway.name` | Name of the MCP Gateway resource | `mcp-gateway` |
 | `mcpGateway.gateway.namespace` | Namespace of the MCP Gateway resource | `gateway-system` |
-| `mcpGateway.hostname` | Hostname for the HTTPRoute | `""` |
+| `mcpGateway.hostname` | Internal routing hostname for the HTTPRoute | `<fullname>.mcp.local` |
 | `mcpGateway.toolPrefix` | Prefix for tools exposed via the gateway | `stackrox_` |
 
 ## Verification


### PR DESCRIPTION
### Description

Add opt-in MCP Gateway integration to the Helm chart, enabling StackRox MCP server registration with [MCP Gateway](https://github.com/Kuadrant/mcp-gateway) for tool aggregation behind a centralized gateway endpoint.

When enabled (`mcpGateway.enabled: true`), the chart creates:
- **HTTPRoute** — routes `/mcp` traffic from the gateway to the StackRox MCP service
- **MCPServerRegistration** — registers the server with the gateway using a configurable tool prefix (`stackrox_` by default)

The chart validates that the required CRDs (`gateway.networking.k8s.io/v1` and `mcp.kagenti.com/v1alpha1`) are available on the cluster and fails with a descriptive error if they are not.

**Files added:**
- `charts/stackrox-mcp/templates/http-route.yaml`
- `charts/stackrox-mcp/templates/mcp-server-registration.yaml`
- `docs/mcp-gateway-integration.md`

**Files modified:**
- `charts/stackrox-mcp/values.yaml` — new `mcpGateway` section
- `charts/stackrox-mcp/README.md` — MCP Gateway configuration table

### Validation

- [x] Helm template renders correctly with MCP Gateway enabled and both API versions available
- [x] Helm fails with descriptive error when Gateway API CRD is missing
- [x] Helm fails with descriptive error when MCPServerRegistration CRD is missing
- [x] No gateway resources rendered when `mcpGateway.enabled: false` (default)
- [x] `helm lint` passes
- [x] Deploy on OpenShift cluster with MCP Gateway installed

### AI-assisted development prompts

This PR was developed with AI assistance. Below are the prompts used:

> **Prompt:** "check https://redhat.atlassian.net/browse/ROX-33010 jira ticket (you can use acli command) and identify what needs to be done."
> **Response:** Fetched the Jira ticket and its attached `stackrox-mcp-registration.yaml` example. Identified the three deliverables: Helm templates for HTTPRoute and MCPServerRegistration, configurable values, and documentation.

> **Prompt:** "MCP Gateway integration should be opt-in for Helm chart. Also it would be good to check capabilities that MCPServerRegistration exists and if not, helm should fail. Create bead with implementation plan and output plan for review."
> **Response:** Created a bead and produced a 6-step implementation plan covering values.yaml, two templates with CRD capability validation, helpers, documentation, and README updates.

> **Prompt:** "We need some clarification: 1. We don't need route.pathPrefix (it will always be the same) 2. Why HTTPRoute uses container port? It would be better to use service."
> **Response:** Verified the MCP handler registers at `/` so `/mcp` is hardcoded gateway convention. Confirmed Gateway API spec says backendRef targets Service and port is the Service port. Updated plan accordingly.

> **Prompt:** "Looks good. You can start with implementation"
> **Response:** Implemented all changes: values.yaml mcpGateway section, HTTPRoute and MCPServerRegistration templates with CRD validation, `_helpers.tpl` validation helper, integration docs, and README updates. Validated with helm template and helm lint.

> **Prompt:** "❯ Code review comments:
>   - let's change `mcpGateway.gateway.name` to `stackrox-mcp-gateway`
>   - set `mcpGateway.toolPrefix` to `stackrox_` by default
>   - would it be reasonable to move MCP gateway validation to resource related to MCP Gateway. Similar to what we have for: charts/stackrox-mcp/templates/secret.yaml ?
>   - in integration document we have `Prerequisites` where it's defined that CRDs should be available. Isn't that part of "MCP Gateway installed on the cluster" - looks redundant
>   - in integration document we have several types of Installations - Probably only basinc setup is sufficient. It is expected that experienced devops will check helm options
>   - Verification part can only onclude `curl` - single line for the full flow
>   - double check if `backendRefs` will actually use service instead of pods
>   - change file names to use `-`, similar to pattern to `service-account.yaml`
> 
>   Create bead for review changes and show plan for review."
> **Response:** Applied all 8 review comments: updated defaults, moved validation into each template (matching secret.yaml pattern), renamed files to `http-route.yaml` and `mcp-server-registration.yaml`, simplified docs to single install example and single curl verification, confirmed backendRef correctness.