### PR TITLE
chore(fix): Fix update model evaluation script

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,6 +83,21 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+      # Verify that the mcpchecker JSON output format is compatible with our
+      # doc-generation script. This catches breaking changes in mcpchecker's
+      # output schema before they reach the weekly model-evaluation workflow.
+      - name: Validate eval script compatibility
+        if: always() && steps.parse_results.outcome == 'success'
+        run: |
+          RESULTS_FILE="e2e-tests/mcpchecker/mcpchecker-stackrox-mcp-e2e-out.json"
+          if [ -f "$RESULTS_FILE" ]; then
+            ./scripts/update-model-evaluation.sh \
+              --model-id "smoke-test" \
+              --results "$RESULTS_FILE"
+            # Revert the doc file.
+            git checkout docs/model-evaluation.md
+          fi
+
       - name: Upload test artifacts
         if: always()
         id: upload_artifacts

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -70,10 +70,10 @@ Results are saved to `mcpchecker/mcpchecker-stackrox-mcp-e2e-out.json`.
 
 ```bash
 # Summary
-jq '.[] | {taskName, taskPassed}' mcpchecker/mcpchecker-stackrox-mcp-e2e-out.json
+jq '.results[] | {taskName, taskPassed}' mcpchecker/mcpchecker-stackrox-mcp-e2e-out.json
 
 # Tool calls
-jq '[.[] | .callHistory.ToolCalls[]? | {name: .request.Params.name, arguments: .request.Params.arguments}]' mcpchecker/mcpchecker-stackrox-mcp-e2e-out.json
+jq '[.results[] | .callHistory.ToolCalls[]? | {name: .request.Params.name, arguments: .request.Params.arguments}]' mcpchecker/mcpchecker-stackrox-mcp-e2e-out.json
 ```
 
 ## Test Cases

--- a/scripts/update-model-evaluation.sh
+++ b/scripts/update-model-evaluation.sh
@@ -76,8 +76,8 @@ END_MARKER="<!-- model:${MODEL_ID} end -->"
 # Generate the markdown block
 generate_block() {
     local total passed
-    total=$(jq 'length' "${RESULTS_FILE}")
-    passed=$(jq '[.[] | select(.taskPassed == true)] | length' "${RESULTS_FILE}")
+    total=$(jq '.results | length' "${RESULTS_FILE}")
+    passed=$(jq '[.results[] | select(.taskPassed == true)] | length' "${RESULTS_FILE}")
     local pct=$((100 * passed / total))
 
     echo "${START_MARKER}"
@@ -93,7 +93,7 @@ generate_block() {
 
     # Generate table rows
     jq -r '
-        to_entries[] |
+        .results | to_entries[] |
         .key as $i |
         .value |
         ($i + 1) as $num |
@@ -123,8 +123,8 @@ generate_block() {
 
     # Token totals
     local input_tokens output_tokens
-    input_tokens=$(jq '[.[].tokenEstimate.inputTokens] | add' "${RESULTS_FILE}")
-    output_tokens=$(jq '[.[].tokenEstimate.outputTokens] | add' "${RESULTS_FILE}")
+    input_tokens=$(jq '[.results[].tokenEstimate.inputTokens] | add' "${RESULTS_FILE}")
+    output_tokens=$(jq '[.results[].tokenEstimate.outputTokens] | add' "${RESULTS_FILE}")
     echo "**Total input tokens**: ${input_tokens} | **Total output tokens**: ${output_tokens}"
     echo ""
     echo "${END_MARKER}"


### PR DESCRIPTION
### Description

The weekly model evaluation workflow ([example failure](https://github.com/stackrox/stackrox-mcp/actions/runs/25362392033)) started failing after the mcpchecker bump from v0.0.17 to v0.0.18. The new version changed the JSON output format from a bare array (`[{...}, ...]`) to a wrapper object (`{"results": [...], "summary": {...}}`), breaking all jq queries in `scripts/update-model-evaluation.sh`.

This PR:
- Updates all 5 jq queries in `update-model-evaluation.sh` to access results via `.results[]` instead of `.[]`
- Updates jq example commands in `e2e-tests/README.md` to match the new format
- Adds a validation step to the E2E PR workflow (`.github/workflows/e2e.yml`) that runs `update-model-evaluation.sh` against real mcpchecker output, catching format regressions before they reach the weekly workflow

### Validation

- [x] E2E tests pass in CI with the new validation step
- [x] Checked all `jq` queries with new version of mcpchecker output

### AI-assisted development prompts

This PR was developed with AI assistance. Below are the prompts used:

> **Prompt:** "I have noticed that weekly module evaluation update is failing. Here's one job example: https://github.com/stackrox/stackrox-mcp/actions/runs/25362392033 - It could be related to update of mcpchecker. Investigate the problem. You can download artifacts from GitHub from that workflow and run locally E2E tests so that you can see output of new version of with new version of MCP checker and then compare results and create a plan what is supposed to be done. Please put everything in beads and output plan for review."
> **Response:** Downloaded CI artifacts, explored the codebase, identified that mcpchecker v0.0.18 changed JSON output from a bare array to `{"results": [...], "summary": {...}}`. Ran E2E tests locally (11/11 pass) and reproduced the jq error. Created a plan to fix all 5 jq queries in `update-model-evaluation.sh` and 2 jq examples in `e2e-tests/README.md`.

> **Prompt:** "File 'mcpchecker-stackrox-mcp-e2e-out.json' should not be committed. It's ignored in .gitignore. (step 3)"
> **Response:** Removed step 3 from the plan — verified the file is gitignored via `.gitignore:32: /e2e-tests/**/mcpchecker`. Plan reduced to 2 file changes.

> **Prompt:** "We have a few smoke tests. Would be possible to add these jq queries in a smoke test so that we can ensure that we are not breaking some scripts."
> **Response:** Explored existing smoke test infrastructure (shell-based smoke tests, Go smoke tests, WireMock tests). Proposed three options for where to place the test.

> **Prompt:** (Selected: "New script scripts/smoke-test-eval-script.sh")
> **Response:** Designed a plan for a standalone shell script with a minimal JSON fixture, Makefile target, and CI wiring in `test.yml`.

> **Prompt:** "Actually I don't like this plan. Let's do something else. The problem that I see is that we need to add fixtures to test jq, but actually we are more interested that new version of MCP checker does not introduce regression and make our defined queries obsolete. How about adding step to already existing E2E tests where we have MCP checker output to check after output is created that its format is not breaking other scripts. In file: '.github/workflows/e2e.yml' - What is your thought about this proposal? Make a critical analysis of this proposal."
> **Response:** Provided a critical analysis with strengths (tests real output, no fixtures to maintain, no extra cost) and considerations (step ordering, doc file revert needed). Recommended the approach as superior to fixtures.

> **Prompt:** (Selected: "Just the script validation")
> **Response:** Revised the plan to add a single validation step to `e2e.yml` that runs `update-model-evaluation.sh` against real mcpchecker output and reverts the doc file afterward.

> **Prompt:** "This looks good. The only thing that I would like to change is to add comments to YAML file that provide information what we are achieving there and why we are doing checkout so that it's clear for our reviewer or another developer what's going on."
> **Response:** Added descriptive YAML comments explaining the purpose of the validation step and why `git checkout` reverts the doc file.