### PR TITLE
ROX-34386: Split main and release pipeline to remove image expire

### DIFF
--- a/.tekton/acs-mcp-server-push-main.yaml
+++ b/.tekton/acs-mcp-server-push-main.yaml
@@ -6,29 +6,30 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "10"
     pipelinesascode.tekton.dev/on-label: "[]"
+    # For push trigger:
+    # - trigger on commit push on main.
+    # For PR triggers:
     # - body.action != "ready_for_review" prevents double-triggering when a draft PR is marked ready for review.
-    # - trigger only for PRs on main and release branches.
-    # - support triggering by label: "konflux-build"
+    # - trigger only for PRs on main branch with label: "konflux-build"
     pipelinesascode.tekton.dev/on-cel-expression: |
       (
-        event == "pull_request" && body.action != "ready_for_review" && (
-          target_branch == "main" ||
-          target_branch.startsWith("release-") ||
-          (
-            has(body.pull_request) &&
-            has(body.pull_request.labels) &&
-            body.pull_request.labels.exists(l, l.name == "konflux-build")
-          )
-        )
+        event == "push" &&
+        target_branch.matches("^main$")
+      ) || (
+        event == "pull_request" &&
+        target_branch.matches("^main$") &&
+        body.action != "ready_for_review" &&
+        has(body.pull_request) &&
+        has(body.pull_request.labels) &&
+        body.pull_request.labels.exists(l, l.name == "konflux-build")
       )
   labels:
     appstudio.openshift.io/application: agentic-cluster-security-suite-0-2
     appstudio.openshift.io/component: acs-mcp-server-0-2
     pipelines.appstudio.openshift.io/type: build
-  name: acs-mcp-server-on-pull-request
+  name: acs-mcp-server-on-push-main
   namespace: agentic-cluster-security-suite-tenant
 spec:
   params:
@@ -38,8 +39,6 @@ spec:
     value: '{{revision}}'
   - name: output-image-repo
     value: quay.io/redhat-user-workloads/agentic-cluster-security-suite-tenant/acs-mcp-server
-  - name: image-expires-after
-    value: "5d"
   - name: dockerfile
     value: konflux.Dockerfile
   - name: hermetic
@@ -50,10 +49,22 @@ spec:
         { "type": "gomod", "path": "." },
         { "type": "rpm", "path": "." }
       ]
+  - name: build-source-image
+    value: 'true'
+  - name: build-image-index
+    value: 'true'
+  - name: image-expires-after
+    value: '13w'
   - name: clone-depth
     value: '0'
   - name: clone-fetch-tags
     value: 'true'
+  - name: build-platforms
+    value:
+    - linux/amd64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: extra-labels
     value:
     # X.Y in the cpe label must be adjusted for every version stream.

--- a/.tekton/acs-mcp-server-push-release.yaml
+++ b/.tekton/acs-mcp-server-push-release.yaml
@@ -9,30 +9,27 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "10"
     pipelinesascode.tekton.dev/on-label: "[]"
     # For push trigger:
-    # - trigger on commit push on main or release branch.
+    # - trigger on commit push on release branches.
     # - trigger on tag pushes.
     # For PR triggers:
     # - body.action != "ready_for_review" prevents double-triggering when a draft PR is marked ready for review.
-    # - trigger only for PRs on release branches.
-    # - support triggering by label: "konflux-build"
+    # - trigger only for PRs on release branches with label: "konflux-build"
     pipelinesascode.tekton.dev/on-cel-expression: |
       (
-        event == "push" && target_branch.matches("^(main|release-.*|refs/tags/.*)$")
+        event == "push" && target_branch.matches("^(release-.*|refs/tags/.*)$")
       ) || (
-        event == "pull_request" && body.action != "ready_for_review" && (
-          target_branch.startsWith("release-") ||
-          (
-            has(body.pull_request) && 
-            has(body.pull_request.labels) && 
-            body.pull_request.labels.exists(l, l.name == "konflux-build")
-          )
-        )
+        event == "pull_request" &&
+        target_branch.startsWith("release-") &&
+        body.action != "ready_for_review" &&
+        has(body.pull_request) &&
+        has(body.pull_request.labels) &&
+        body.pull_request.labels.exists(l, l.name == "konflux-build")
       )
   labels:
     appstudio.openshift.io/application: agentic-cluster-security-suite-0-2
     appstudio.openshift.io/component: acs-mcp-server-0-2
     pipelines.appstudio.openshift.io/type: build
-  name: acs-mcp-server-on-push
+  name: acs-mcp-server-on-push-release
   namespace: agentic-cluster-security-suite-tenant
 spec:
   params:
@@ -56,8 +53,6 @@ spec:
     value: 'true'
   - name: build-image-index
     value: 'true'
-  - name: image-expires-after
-    value: '13w'
   - name: clone-depth
     value: '0'
   - name: clone-fetch-tags


### PR DESCRIPTION
### Description

This PR splits release and main branch on push pipeline.

This solution keeps base component pipeline simple and without any custom logic.

### Validation

- [x] Check push Konflux pipeline run
- [x] Trigger run with label - check that release pipeline is used
- [x] Check that image build with release pipeline triggered by label does not contain expire label
- [x] Check that Snyk runs (this was one of conforma failures and secret is added)
