### PR TITLE
chore(Konflux): Enable MintMaker auto-merge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,20 +32,23 @@
     "tekton",
   ],
   "dockerfile": {
+    "automerge": true,
     "includePaths": [
       "konflux.Dockerfile",
     ],
   },
   "rpm-lockfile": {
+    "automerge": true,
     "schedule": [
       // Duplicate the schedule here because Konflux global config may have a special override for rpm-lockfile.
-      "* 3-7 * * *",
+      "* 2-8 * * *",
     ],
   },
   "tekton": {
+    "automerge": true,
     "schedule": [
       // Duplicate the schedule here because Konflux global config may have a special override for tekton.
-      "* 3-7 * * *",
+      "* 2-8 * * *",
     ],
   },
 }


### PR DESCRIPTION
### Description

We are getting a lot of updates from Mint Maker (Renovate) - almost everyday at least one PR.

These PRs are in most cases just bumps of versions and review is trivial, but process of merging them requires manual intervention and it's slowed down. Especially in cases where we need to rebase.

This change should enabled auto-merge and reduce manual effort.

Added a few changes to this repo:
- added that Konflux on pull request pipeline run is required to merge
- added permissions for Konflux Bot to be able to merge without waiting for approvals

This PR also extends schedule between `2-8` to give space for 2 renovate runs (every 4 hours).

### Validation

- [x] Checked config with `make renovate-validate`
